### PR TITLE
Turn off strict rule

### DIFF
--- a/rules/style.js
+++ b/rules/style.js
@@ -34,7 +34,7 @@ module.exports = {
             anonymous: 'always',
             named: 'never'
         }],
-        strict: ['error', 'never'],
+        strict: 'off',
         'valid-jsdoc': ['error', {
             requireParamDescription: false,
             requireReturnDescription: false,


### PR DESCRIPTION
@fnwbr This rule causes problems for the QA tests written in Node. In order for us to use `let` and `const` in Node, we have to declare strict mode at the top of modules. However, this rule says that's in error.

One solution would be to disable this rule at the top of every node.js file (yuck), or we can just turn it off. Since we don't ever have this problem anywhere else in our code, I'm fine with just turning it off everywhere.