### PR TITLE
Turn off tabindex-no-positive rule

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -20,6 +20,8 @@ module.exports = {
         // This is also a warning as its a best practice to not use strings, but its not being deprecated either
         'react/no-string-refs': 'warn',
         // Turn this off entirely because we like to click on things like <h3>s
-        'jsx-a11y/no-static-element-interactions': 'off'
+        'jsx-a11y/no-static-element-interactions': 'off',
+        // Allow us to use positive tabIndex property values
+        'jsx-a11y/tabindex-no-positive': 'off'
     }
 };


### PR DESCRIPTION
Discussed [here](https://github.com/Expensify/Web-Expensify/pull/22798#issuecomment-432210355) to make the linter pass in the PR