### PR TITLE
Update ESLint to latest (and add lines-around-comment rule)

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,12 +12,11 @@ module.exports = {
         node: true
     },
     parserOptions: {
-        ecmaVersion: 2017,
+        ecmaVersion: 2018,
         sourceType: 'module',
         ecmaFeatures: {
             generators: true,
-            objectLiteralDuplicateProperties: true,
-            experimentalObjectRestSpread: true
+            objectLiteralDuplicateProperties: true
         }
     }
 };

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "url": "git+https://github.com/Expensify/eslint-config-expensify.git"
   },
   "dependencies": {
-    "eslint": "4.7.2",
-    "eslint-config-airbnb": "15.1.0",
-    "eslint-config-airbnb-base": "11.3.2",
-    "eslint-plugin-import": "2.7.0",
-    "eslint-plugin-jsx-a11y": "5.1.1",
-    "eslint-plugin-react": "7.4.0"
+    "eslint": "5.16.0",
+    "eslint-config-airbnb": "17.1.0",
+    "eslint-config-airbnb-base": "13.1.0",
+    "eslint-plugin-import": "2.16.0",
+    "eslint-plugin-jsx-a11y": "6.2.0",
+    "eslint-plugin-react": "7.12.4"
   },
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-expensify",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Expensify's ESLint configuration following our style guide",
   "main": "index.js",
   "repository": {

--- a/rules/react.js
+++ b/rules/react.js
@@ -2,8 +2,10 @@ module.exports = {
     rules: {
         // Do not prevent multiple component definition per file
         'react/no-multi-comp': 'off',
+
         // Do not prevent missing React when using JSX
         'react/react-in-jsx-scope': 'off',
+
         // Enforce indentation of 4 spaces
         'react/jsx-indent-props': ['error', 4],
         'react/jsx-indent': ['error', 4],
@@ -13,10 +15,13 @@ module.exports = {
         'react/prefer-es6-class': 'warn',
         'react/prefer-stateless-function': 'warn',
         'react/prop-types': 'warn',
+
         // findDOMNode() will be an error, use refs instead
         'react/no-find-dom-node': 'warn',
+
         // This will only be a warning, to promote us to write better propTypes
         'react/forbid-prop-types': 'warn',
+
         // This is also a warning as its a best practice to not use strings, but its not being deprecated either
         'react/no-string-refs': 'warn'
     }

--- a/rules/style.js
+++ b/rules/style.js
@@ -10,13 +10,13 @@ module.exports = {
         'import/no-dynamic-require': 'off',
         'import/no-extraneous-dependencies': 'off',
         'import/no-unresolved': 'off',
+
         // Enforce indentation of 4 spaces; the third option parameter was copied from Airbnb:
         // https://github.com/airbnb/javascript/blob/60b96d322277c4c71a21a05caba8eb3320e0e3fa/packages/eslint-config-airbnb-base/rules/style.js#L120-L145
         indent: ['error', 4, {
             SwitchCase: 1,
             VariableDeclarator: 1,
             outerIIFEBody: 1,
-            // MemberExpression: null,
             FunctionDeclaration: {
                 parameters: 1,
                 body: 1
@@ -32,10 +32,12 @@ module.exports = {
             ObjectExpression: 1,
             ImportDeclaration: 1,
             flatTernaryExpressions: false,
+
             // list derived from https://github.com/benjamn/ast-types/blob/HEAD/def/jsx.js
             ignoredNodes: ['JSXElement', 'JSXElement > *', 'JSXAttribute', 'JSXIdentifier', 'JSXNamespacedName', 'JSXMemberExpression', 'JSXSpreadAttribute', 'JSXExpressionContainer', 'JSXOpeningElement', 'JSXClosingElement', 'JSXText', 'JSXEmptyExpression', 'JSXSpreadChild'],
             ignoreComments: false
         }],
+
         // Airbnb didn't want this rule to be enabled even though it complies with their styleguide - so we're adding it
         // https://github.com/airbnb/javascript/pull/1994
         'lines-around-comment': ['error', {
@@ -63,6 +65,7 @@ module.exports = {
         'no-plusplus': 'off',
         'no-return-assign': 'off',
         'object-curly-spacing': ['error', 'never'],
+
         // Require space before function opening parenthesis
         'space-before-function-paren': ['error', {
             anonymous: 'always',
@@ -75,6 +78,7 @@ module.exports = {
             requireReturn: false
         }],
         'vars-on-top': 'off',
+
         // This enforces wrapping always the function expression.
         'wrap-iife': ['error', 'inside']
     }

--- a/rules/style.js
+++ b/rules/style.js
@@ -10,8 +10,32 @@ module.exports = {
         'import/no-dynamic-require': 'off',
         'import/no-extraneous-dependencies': 'off',
         'import/no-unresolved': 'off',
-        // Enforce indentation of 4 spaces
-        indent: ['error', 4],
+        // Enforce indentation of 4 spaces; the third option parameter was copied from Airbnb:
+        // https://github.com/airbnb/javascript/blob/60b96d322277c4c71a21a05caba8eb3320e0e3fa/packages/eslint-config-airbnb-base/rules/style.js#L120-L145
+        indent: ['error', 4, {
+            SwitchCase: 1,
+            VariableDeclarator: 1,
+            outerIIFEBody: 1,
+            // MemberExpression: null,
+            FunctionDeclaration: {
+                parameters: 1,
+                body: 1
+            },
+            FunctionExpression: {
+                parameters: 1,
+                body: 1
+            },
+            CallExpression: {
+                arguments: 1
+            },
+            ArrayExpression: 1,
+            ObjectExpression: 1,
+            ImportDeclaration: 1,
+            flatTernaryExpressions: false,
+            // list derived from https://github.com/benjamn/ast-types/blob/HEAD/def/jsx.js
+            ignoredNodes: ['JSXElement', 'JSXElement > *', 'JSXAttribute', 'JSXIdentifier', 'JSXNamespacedName', 'JSXMemberExpression', 'JSXSpreadAttribute', 'JSXExpressionContainer', 'JSXOpeningElement', 'JSXClosingElement', 'JSXText', 'JSXEmptyExpression', 'JSXSpreadChild'],
+            ignoreComments: false
+        }],
         // Airbnb didn't want this rule to be enabled even though it complies with their styleguide - so we're adding it
         // https://github.com/airbnb/javascript/pull/1994
         'lines-around-comment': ['error', {

--- a/rules/style.js
+++ b/rules/style.js
@@ -12,6 +12,15 @@ module.exports = {
         'import/no-unresolved': 'off',
         // Enforce indentation of 4 spaces
         indent: ['error', 4],
+        // Airbnb didn't want this rule to be enabled even though it complies with their styleguide - so we're adding it
+        // https://github.com/airbnb/javascript/pull/1994
+        'lines-around-comment': ['error', {
+            beforeLineComment: true,
+            allowBlockStart: true,
+            allowObjectStart: true,
+            allowArrayStart: true,
+            allowClassStart: true,
+        }],
         'max-len': ['warn', {
             code: 120
         }],


### PR DESCRIPTION
Heyho! Small update on our ESLint config. I'll also leave these comments on the diff:

1. I wanted to close this issue: https://github.com/Expensify/Expensify/issues/89615 which was about enforcing a certain style that has been part of the style guide for a long time already. (See that I tried to enable this rule in Airbnb's base package but they didn't like it: https://github.com/airbnb/javascript/pull/1994)
2. I updated all of the dependencies to the latest.
3. I noticed a while ago that the `switch () {}` statements in JS always enforced a wrong indentation... looks like that's because we (accidentally) told ESLint to do so. Fixed it in this PR, see `indent` rule).