### PR TITLE
List ESLint and plugins as peerDependencies + use `babel-eslint` parser

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-    extends: './index.js'
-}
+    extends: './legacy.js'
+};

--- a/index.js
+++ b/index.js
@@ -11,12 +11,5 @@ module.exports = {
         jquery: true,
         node: true
     },
-    parserOptions: {
-        ecmaVersion: 2018,
-        sourceType: 'module',
-        ecmaFeatures: {
-            generators: true,
-            objectLiteralDuplicateProperties: true
-        }
-    }
+    parser: 'babel-eslint'
 };

--- a/package.json
+++ b/package.json
@@ -8,9 +8,17 @@
     "url": "git+https://github.com/Expensify/eslint-config-expensify.git"
   },
   "dependencies": {
-    "eslint": "5.16.0",
     "eslint-config-airbnb": "17.1.0",
-    "eslint-config-airbnb-base": "13.1.0",
+    "eslint-config-airbnb-base": "13.1.0"
+  },
+  "devDependencies": {
+    "eslint": "5.16.0",
+    "eslint-plugin-import": "2.16.0",
+    "eslint-plugin-jsx-a11y": "6.2.0",
+    "eslint-plugin-react": "7.12.4"
+  },
+  "peerDependencies": {
+    "eslint": "5.16.0",
     "eslint-plugin-import": "2.16.0",
     "eslint-plugin-jsx-a11y": "6.2.0",
     "eslint-plugin-react": "7.12.4"

--- a/package.json
+++ b/package.json
@@ -12,11 +12,7 @@
     "eslint-config-airbnb-base": "13.1.0"
   },
   "devDependencies": {
-    "babel-eslint": "10.0.1",
-    "eslint": "5.16.0",
-    "eslint-plugin-import": "2.16.0",
-    "eslint-plugin-jsx-a11y": "6.2.0",
-    "eslint-plugin-react": "7.12.4"
+    "eslint": "5.16.0"
   },
   "peerDependencies": {
     "babel-eslint": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-expensify",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Expensify's ESLint configuration following our style guide",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -12,12 +12,14 @@
     "eslint-config-airbnb-base": "13.1.0"
   },
   "devDependencies": {
+    "babel-eslint": "10.0.1",
     "eslint": "5.16.0",
     "eslint-plugin-import": "2.16.0",
     "eslint-plugin-jsx-a11y": "6.2.0",
     "eslint-plugin-react": "7.12.4"
   },
   "peerDependencies": {
+    "babel-eslint": "10.0.1",
     "eslint": "5.16.0",
     "eslint-plugin-import": "2.16.0",
     "eslint-plugin-jsx-a11y": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-expensify",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Expensify's ESLint configuration following our style guide",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Sorry - this is some back and forth after https://github.com/Expensify/eslint-config-expensify/pull/7.
But when I was trying to install the update to our Web-Expensify repository I noticed that ESLint does not scan subdirectories of `node_modules/` for plugins anymore.

So it is not enough to list e.g. `eslint-plugin-react` as a dependency of this package anymore, but we need to actually install it as a separate first-level dependency in Web-Expensify.

To do so properly, you'd mention them here as `peerDependency`.

**Extra note:** ESLint is working on undoing that at some point again, the RFC proposal was accepted already: https://github.com/eslint/rfcs/pull/7
But the actual implementation is still pending: https://github.com/eslint/rfcs/pull/14

And I don't really want to hold on that now.

---

Second thing: We need to use `babel-eslint` as our parser, because (for whatever reason) ESLint seems to have dropped the support to do React out of the box. I couldn't really find the changelog item pointing that out, but with this change everything is working again. Allegedly it has always been like that, but that made me wonder how it has worked in the past for us. Let me know if you have other ideas, but we acn also just merge this as is.