### PR TITLE
Disable label-has-for eslint rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-expensify",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Expensify's ESLint configuration following our style guide",
   "main": "index.js",
   "repository": {

--- a/rules/style.js
+++ b/rules/style.js
@@ -11,6 +11,7 @@ module.exports = {
         'import/no-extraneous-dependencies': 'off',
         'import/no-unresolved': 'off',
         'jsx-a11y/click-events-have-key-events': 'off',
+        'jsx-a11y/label-has-for': 'off',
 
         // Enforce indentation of 4 spaces; the third option parameter was copied from Airbnb:
         // https://github.com/airbnb/javascript/blob/60b96d322277c4c71a21a05caba8eb3320e0e3fa/packages/eslint-config-airbnb-base/rules/style.js#L120-L145


### PR DESCRIPTION
Disable an already deprecated ESLint rule that was causing some weird css bugs in concierge.

[Here](https://expensify.slack.com/archives/C03TQ48KC/p1560286052113700) is the slack conversation brought about this change. 