### PR TITLE
Move a rule so it's not applied to legacy code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-expensify",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Expensify's ESLint configuration following our style guide",
   "main": "index.js",
   "repository": {

--- a/rules/es6.js
+++ b/rules/es6.js
@@ -5,5 +5,11 @@ module.exports = {
         // Rather then blindly enforcing destructuring assignments, we'll trust the author's best judgement on when
         // to make use of them, and when not; see https://github.com/Expensify/Style-Guide/pull/60 for more details
         'prefer-destructuring': 'off',
+
+        // By default, this rules makes us use both "for" attributes and nest inputs inside of
+        // labels. We would rather just do either since browsers don't have a preference.
+        'jsx-a11y/label-has-associated-control': ['error', {
+            assert: 'either',
+        }],
     }
 };

--- a/rules/style.js
+++ b/rules/style.js
@@ -13,12 +13,6 @@ module.exports = {
         'jsx-a11y/click-events-have-key-events': 'off',
         'jsx-a11y/label-has-for': 'off',
 
-        // By default, this rules makes us use both "for" attributes and nest inputs inside of
-        // labels. We would rather just do either since browsers don't have a preference.
-        'jsx-a11y/label-has-associated-control': ['error', {
-            assert: 'either',
-        }],
-
         // Enforce indentation of 4 spaces; the third option parameter was copied from Airbnb:
         // https://github.com/airbnb/javascript/blob/60b96d322277c4c71a21a05caba8eb3320e0e3fa/packages/eslint-config-airbnb-base/rules/style.js#L120-L145
         indent: ['error', 4, {


### PR DESCRIPTION
Fixes an error when linting `.js` files with the legacy linter. 

The legacy linting rules imports the same "style" linting rules, so by moving this definition over to the "es6" rules, we avoid including it in the legacy rules.

```
/Users/dbondy/Expensidev/Web-Expensify/site/class/domain.js
    1:1   error    Definition for rule 'jsx-a11y/label-has-associated-control' was not found  jsx-a11y/label-has-associated-control
  129:13  warning  Assignment to property of function parameter 'nvp'                         no-param-reassign
  133:13  warning  Assignment to property of function parameter 'nvp'                         no-param-reassign
  137:13  warning  Assignment to property of function parameter 'nvp'                         no-param-reassign
  142:16  warning  Assignment to property of function parameter 'nvp'                         no-param-reassign
  143:16  warning  Assignment to property of function parameter 'nvp'                         no-param-reassign
  145:9   warning  Assignment to property of function parameter 'nvp'                         no-param-reassign
  146:1   warning  Line 146 exceeds the maximum line length of 120                            max-len
  257:1   warning  Line 257 exceeds the maximum line length of 120                            max-len
  279:1   warning  Line 279 exceeds the maximum line length of 120                            max-len

✖ 10 problems (1 error, 9 warnings)

Warning: Task "eslint:js" failed.
```

You can test this locally by making the same modifications in your local `node_modules` folder.
