### PR TITLE
Update our ESlint rules to stop warning when an allowed method is used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-expensify",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-expensify",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Expensify's ESLint configuration following our style guide",
   "main": "index.js",
   "repository": {

--- a/rules/style.js
+++ b/rules/style.js
@@ -5,6 +5,7 @@ module.exports = {
         'comma-dangle': 'off',
         'consistent-return': 'off',
         'consistent-this': [1, 'self'],
+        'no-console': ['warn', { allow: ['debug', 'error'] }]
         'func-names': 'off',
         'global-require': 'off',
         'import/no-dynamic-require': 'off',

--- a/rules/style.js
+++ b/rules/style.js
@@ -5,7 +5,7 @@ module.exports = {
         'comma-dangle': 'off',
         'consistent-return': 'off',
         'consistent-this': [1, 'self'],
-        'no-console': ['warn', { allow: ['debug', 'error'] }]
+        'no-console': ['error', { allow: ['debug', 'error'] }]
         'func-names': 'off',
         'global-require': 'off',
         'import/no-dynamic-require': 'off',


### PR DESCRIPTION
We often use `console.debug` and `console.error` but we should never allow `console.log` in our code (it keeps the console clean so that errors and warnings are more visible). This updates our ESLint rules to be more inline with that.