### PR TITLE
Add comma to config so it's not broken

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-expensify",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-expensify",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "Expensify's ESLint configuration following our style guide",
   "main": "index.js",
   "repository": {

--- a/rules/style.js
+++ b/rules/style.js
@@ -5,7 +5,7 @@ module.exports = {
         'comma-dangle': 'off',
         'consistent-return': 'off',
         'consistent-this': [1, 'self'],
-        'no-console': ['error', { allow: ['debug', 'error'] }]
+        'no-console': ['error', { allow: ['debug', 'error'] }],
         'func-names': 'off',
         'global-require': 'off',
         'import/no-dynamic-require': 'off',


### PR DESCRIPTION
fixes error:

```
Running "eslint:jsx" (eslint) task
Warning: Cannot read config file: /Users/ionatan/Expensidev/Web-Expensify/node_modules/eslint-config-expensify/rules/style.js
Error: Unexpected string
Referenced from: /Users/ionatan/Expensidev/Web-Expensify/node_modules/eslint-config-expensify/index.js
Warning: Task "eslint:jsx" failed.
```

cc @tgolen 