### PR TITLE
Enforce most of our react styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-expensify",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "description": "Expensify's ESLint configuration following our style guide",
   "main": "index.js",
   "repository": {

--- a/rules/react.js
+++ b/rules/react.js
@@ -15,14 +15,8 @@ module.exports = {
         'react/prefer-es6-class': 'error',
         'react/prefer-stateless-function': 'error',
         'react/prop-types': 'error',
-
-        // findDOMNode() will be an error, use refs instead
-        'react/no-find-dom-node': 'warn',
-
-        // This will only be a warning, to promote us to write better propTypes
+        'react/no-find-dom-node': 'error',
         'react/forbid-prop-types': 'error',
-
-        // This is also a warning as its a best practice to not use strings, but its not being deprecated either
         'react/no-string-refs': 'error',
 
         // Rather then blindly enforcing destructuring assignments, we'll trust the author's best judgement on when

--- a/rules/react.js
+++ b/rules/react.js
@@ -12,25 +12,22 @@ module.exports = {
         'react/jsx-no-undef': ['error', {
             allowGlobals: true
         }],
-        'react/prefer-es6-class': 'warn',
-        'react/prefer-stateless-function': 'warn',
-        'react/prop-types': 'warn',
+        'react/prefer-es6-class': 'error',
+        'react/prefer-stateless-function': 'error',
+        'react/prop-types': 'error',
 
         // findDOMNode() will be an error, use refs instead
         'react/no-find-dom-node': 'warn',
 
         // This will only be a warning, to promote us to write better propTypes
-        'react/forbid-prop-types': 'warn',
+        'react/forbid-prop-types': 'error',
 
         // This is also a warning as its a best practice to not use strings, but its not being deprecated either
-        'react/no-string-refs': 'warn',
+        'react/no-string-refs': 'error',
 
         // Rather then blindly enforcing destructuring assignments, we'll trust the author's best judgement on when
         // to make use of them, and when not; see https://github.com/Expensify/Style-Guide/pull/60 for more details
-        'react/destructuring-assignment': 'off',
-
-        // We want to force the use of stateless functions when we can
-        'react/prefer-stateless-function': 'error',
+        'react/destructuring-assignment': 'warn',
 
         // New versions of react are removing some methods, and those methods have been prefixed with "UNSAFE_" for now.
         // We need to prevent more usages of these methods and their aliases from being added


### PR DESCRIPTION
A lot of these styles I already enforce during code reviews, so making them errors instead of warnings will make the quality of our code most consistent.

I've added most of the well-known React developers to invite anyone to disagree or push back on these suggested changes.

In most cases, I would prefer to allow people to explicitly suppress errors rather than to keep them as warnings in the linter and then ask them to be changed during a code review.