### PR TITLE
Make the 'no-use-before-define' rule a warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-expensify",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "Expensify's ESLint configuration following our style guide",
   "main": "index.js",
   "repository": {

--- a/rules/style.js
+++ b/rules/style.js
@@ -68,6 +68,7 @@ module.exports = {
         }],
         'no-plusplus': 'off',
         'no-return-assign': 'off',
+        'no-use-before-define': 'warn',
         'object-curly-spacing': ['error', 'never'],
 
         // Require space before function opening parenthesis


### PR DESCRIPTION
$ Unblocks https://github.com/Expensify/Expensify/issues/147491

The `no-use-before-define` rule is incorrectly flagging functions. Functions will actually be hoisted to the top of the file, so this error should be reduced to a warning. [[Further discussion]](https://expensify.slack.com/archives/C03TQ48KC/p1607020490342200?thread_ts=1607018465.328700&cid=C03TQ48KC)

### Test

To verify this change in the ReactNativeChat repo:
- Locate the file `node_modules/eslint-config-expensify/rules/style.js`
- From `ReactNativeChat`, checkout this commit: `git checkout 02b01a72402eba55dd9460ea3854b02e591e7cca`
- Add this line `'no-use-before-define': 'warn',` beneath line 70
- Run `git log`, verify this is the latest commit message: ' add server Log to authToken error flow'
- Run `npm run lint`
- Check for the following **warning**

**Expected warning**
![Screenshot 2020-12-04 at 14 46 30](https://user-images.githubusercontent.com/10736861/101178959-865dcb00-3641-11eb-8705-2eee524421c1.png)

