### PR TITLE
Ban destructuring of props or state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-expensify",
-  "version": "2.0.16",
+  "version": "2.0.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-expensify",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "description": "Expensify's ESLint configuration following our style guide",
   "main": "index.js",
   "repository": {

--- a/rules/react.js
+++ b/rules/react.js
@@ -19,10 +19,7 @@ module.exports = {
         'react/forbid-prop-types': 'error',
         'react/no-string-refs': 'error',
         'react/jsx-filename-extension': [1, {extensions: ['.js']}],
-
-        // Do not warn or error for destructuring
-        // See: https://github.com/Expensify/Style-Guide/blob/master/javascript.md#destructuring
-        'react/destructuring-assignment': 'off',
+        'react/destructuring-assignment': ['error', 'never'],
 
         // New versions of react are removing some methods, and those methods have been prefixed with "UNSAFE_" for now.
         // We need to prevent more usages of these methods and their aliases from being added


### PR DESCRIPTION
This goes along with https://github.com/Expensify/App/pull/6234. Once this PR is merged, we can update that one to point at the new commit hash for `eslint-config-expensify` to include this rule in the Expensify global config.