### PR TITLE
Add `prefer-import-module-contents` custom rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-expensify",
-  "version": "2.0.18",
+  "version": "2.0.19",
   "description": "Expensify's ESLint configuration following our style guide",
   "main": "index.js",
   "repository": {

--- a/rules/expensify.js
+++ b/rules/expensify.js
@@ -9,5 +9,6 @@ module.exports = {
         'rulesdir/no-inline-named-export': 'error',
         'rulesdir/prefer-underscore-method': 'error',
         'rulesdir/no-useless-compose': 'error',
+        'rulesdir/prefer-import-module-contents': 'error',
     },
 };


### PR DESCRIPTION
Should be tested in connection with https://github.com/Expensify/App/pull/6279

Adds a rule to enforce the `import * as Something from './somewhere'` syntax for most things. There are a few exceptions:

- Anything in `/node_modules` as we can't control 3rd party APIs
- `propTypes` because they are sometimes bundled with components and it is convenient to break out `propTypes` and `defaultProps`
- Higher order components because they often have default and named exports mixed
- Anything dealing with Context (i.e. `provider|context`) for the same reason
- `.json` file imports because it is convenient to break off a single property from something in a JSON file


**Part 1 of 2**

https://github.com/Expensify/App/issues/6072