### PR TITLE
Add rule preventing importing certain components from react-native

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ You need to publish the newest version of this to NPM so that we can update it i
 1. Enter password: this is in 1Password for npmjs.com
 1. Enter the email: help@expensify.com
 1. Run `npm publish`
-1. Go into the Web-Expensify and Web-Secure repos and run `npm install eslint-config-expensify@latest`. This should update the `package.json` and `package-lock.json` file and you can submit a PR with those changes.
+1. Go into the App, Web-Expensify and Web-Secure repos and run `npm install eslint-config-expensify@latest`. This should update the `package.json` and `package-lock.json` file and you can submit a PR with those changes.
 
-**Note** as of now we have no way of testing these PRs without a separate Web or Web Secure PR
+**Note** as of now we have no way of testing these PRs without a separate App, Web or Web Secure PR
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-expensify",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "description": "Expensify's ESLint configuration following our style guide",
   "main": "index.js",
   "repository": {

--- a/rules/expensify.js
+++ b/rules/expensify.js
@@ -13,8 +13,8 @@ module.exports = {
         'no-restricted-imports': ['error', {
             'paths': [{
                 'name': 'react-native',
-                'importNames': ['Button', 'Text'],
-                'message': 'Please use ExpensifyText or ExpensifyButton from src/components/ instead.'
+                'importNames': ['Button', 'Text', 'TextInput'],
+                'message': 'Please use an Expensify component from src/components/ instead.'
             }]
         }]
     },

--- a/rules/expensify.js
+++ b/rules/expensify.js
@@ -10,5 +10,12 @@ module.exports = {
         'rulesdir/prefer-underscore-method': 'error',
         'rulesdir/no-useless-compose': 'error',
         'rulesdir/prefer-import-module-contents': 'error',
+        'no-restricted-imports': ['error', {
+            'paths': [{
+                'name': 'react-native',
+                'importNames': ['Button', 'TouchableOpacity', 'Text'],
+                'message': 'Please use ExpensifyText or ExpensifyButton from src/components/ instead.'
+            }]
+        }]
     },
 };

--- a/rules/expensify.js
+++ b/rules/expensify.js
@@ -13,7 +13,7 @@ module.exports = {
         'no-restricted-imports': ['error', {
             'paths': [{
                 'name': 'react-native',
-                'importNames': ['Button', 'TouchableOpacity', 'Text'],
+                'importNames': ['Button', 'Text'],
                 'message': 'Please use ExpensifyText or ExpensifyButton from src/components/ instead.'
             }]
         }]


### PR DESCRIPTION
In this [issue](https://github.com/Expensify/App/issues/3133)/[PR](https://github.com/Expensify/App/pull/6538) I have renamed our custom `Text` and `Button` components to `ExpensifyText` and `ExpensifyButton`. We want contributors to use these custom components rather than using the default `Text` and `Button` components from `react-native`. 

This rule will throw a lint error when either of those two components is imported from React Native. That looks like the following: 
![image](https://user-images.githubusercontent.com/1371996/144466115-57d04dd4-b176-4bff-9196-7020da4099a7.png)


The rule can be suppressed by adding a comment like `// eslint-disable-next-line no-restricted-imports`.

I have also updated the Readme to say that the App repo needs to be updated after the ESLint configuration is updated, not just Web and Web-Secure. 

And finally, I have a list of follow-up todos once this PR is merged here: https://github.com/Expensify/Expensify/issues/187203