### PR TITLE
Restrict react native Picker import 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-expensify",
-  "version": "2.0.20",
+  "version": "2.0.21",
   "description": "Expensify's ESLint configuration following our style guide",
   "main": "index.js",
   "repository": {

--- a/rules/expensify.js
+++ b/rules/expensify.js
@@ -13,7 +13,7 @@ module.exports = {
         'no-restricted-imports': ['error', {
             'paths': [{
                 'name': 'react-native',
-                'importNames': ['Button', 'Text', 'TextInput'],
+                'importNames': ['Button', 'Text', 'TextInput', 'Picker'],
                 'message': 'Please use an Expensify component from src/components/ instead.'
             }]
         }]


### PR DESCRIPTION
This is a follow up to https://github.com/Expensify/eslint-config-expensify/pull/38. There is one other `react-native` component we shadow - Picker. So this adds it to the list of restricted imports from React Native. Context here: https://expensify.slack.com/archives/C01GTK53T8Q/p1639149638008700

If someone does try to import it, it will throw a lint error like below. 
![image](https://user-images.githubusercontent.com/1371996/146055146-efd5ff69-4c98-4a01-bd29-585e4b601afa.png)

Follow up steps after this is merged are here: https://github.com/Expensify/App/issues/6756

@tgolen there's no puller bear in this repo. So since you likely have the most context from the thread, I'm assigning you 😄. 