### PR TITLE
Update readme with updated npm email address

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You need to publish the newest version of this to NPM so that we can update it i
 1. Run `npm login`
 1. Enter username: 'expensify'
 1. Enter password: this is in 1Password for npmjs.com
-1. Enter the email: help@expensify.com
+1. Enter the email: infra@expensify.com
 1. Run `npm publish`
 1. Go into the App, Web-Expensify and Web-Secure repos and run `npm install eslint-config-expensify@latest`. This should update the `package.json` and `package-lock.json` file and you can submit a PR with those changes.
 


### PR DESCRIPTION
We updated the email address on our npmjs account (context [here](https://expensify.slack.com/archives/C06N6E4RF/p1639594898396600)). This updates the instructions in the readme to reflect that. 

There is no puller bear in this repo, so @coleaeason I choose you since you were the main person I was talking with in that Slack thread. 