### PR TITLE
Fix isFalsePositive in no-negated-variables

### DIFF
--- a/eslint-plugin-expensify/no-negated-variables.js
+++ b/eslint-plugin-expensify/no-negated-variables.js
@@ -2,12 +2,23 @@ const _ = require('underscore');
 const lodashGet = require('lodash/get');
 const message = require('./CONST').MESSAGE.NO_NEGATED_VARIABLES;
 
+const NOTABLE_EXCEPTIONS = [
+    'notification',
+    'notch',
+    'note',
+    'notable',
+    'notion',
+    'notice',
+];
+
 /**
  * @param {String} string
  * @returns {Boolean}
  */
 function isFalsePositive(string) {
-    const matches = /(.*?)(?:[nN](?:otification|otch|ote))+(.*)/gm.exec(string);
+    const buzzWordMatcher = new RegExp(`[nN](?:${_.map(NOTABLE_EXCEPTIONS, word => word.slice(1)).join('|')})`);
+    const regex = new RegExp(`(.*?)(?:${buzzWordMatcher.source})+(.*)`, 'gm');
+    const matches = regex.exec(string);
 
     if (!matches) {
         return false;
@@ -16,7 +27,7 @@ function isFalsePositive(string) {
     const prefix = matches[1];
     const suffix = matches[2];
 
-    if (_.some([prefix, suffix], s => /.*[nN](?:ot).*/.test(s))) {
+    if (_.some([prefix, suffix], s => /.*[nN](?:ot).*/.test(s) && !buzzWordMatcher.test(s))) {
         return false;
     }
 

--- a/eslint-plugin-expensify/no-negated-variables.js
+++ b/eslint-plugin-expensify/no-negated-variables.js
@@ -20,17 +20,14 @@ const NOTABLE_EXCEPTIONS = [
     'notice',
 ];
 
-// Declared up front to suppress eslint no-use-before-define
-// Mutually recursive functions are a valid exception to this rule. See https://github.com/eslint/eslint/issues/12473
-let isNegatedVariableName;
-
 /**
  * @param {String} string
  * @returns {Boolean}
  */
-const isFalsePositive = (string) => {
+function isFalsePositive(string) {
     const buzzWordMatcher = new RegExp(`[nN](?:${_.map(NOTABLE_EXCEPTIONS, word => word.slice(1)).join('|')})`);
-    const regex = new RegExp(`(.*)${buzzWordMatcher.source}(.*)`, 'm');
+    const upperSnakeCaseMatcher = new RegExp(`_?${_.map(NOTABLE_EXCEPTIONS, word => word.toUpperCase()).join('|')}_?`);
+    const regex = new RegExp(`(.*)(?:${buzzWordMatcher.source}|${upperSnakeCaseMatcher.source})(.*)`, 'm');
     const matches = regex.exec(string);
 
     if (!matches) {
@@ -40,7 +37,9 @@ const isFalsePositive = (string) => {
     const prefix = matches[1];
     const suffix = matches[2];
 
+    // eslint-disable-next-line no-use-before-define
     const isPrefixNegatedVariableName = isNegatedVariableName(prefix);
+    // eslint-disable-next-line no-use-before-define
     const isSuffixNegatedVariableName = isNegatedVariableName(suffix);
 
     return !isPrefixNegatedVariableName && !isSuffixNegatedVariableName;
@@ -50,7 +49,7 @@ const isFalsePositive = (string) => {
  * @param {String} name
  * @returns {Boolean}
  */
-isNegatedVariableName = (name) => {
+function isNegatedVariableName(name) {
     if (!name) {
         return;
     }

--- a/eslint-plugin-expensify/no-negated-variables.js
+++ b/eslint-plugin-expensify/no-negated-variables.js
@@ -30,7 +30,7 @@ let isNegatedVariableName;
  */
 const isFalsePositive = (string) => {
     const buzzWordMatcher = new RegExp(`[nN](?:${_.map(NOTABLE_EXCEPTIONS, word => word.slice(1)).join('|')})`);
-    const regex = new RegExp(`(.*?)(?:${buzzWordMatcher.source})+(.*)`, 'm');
+    const regex = new RegExp(`(.*)${buzzWordMatcher.source}(.*)`, 'm');
     const matches = regex.exec(string);
 
     if (!matches) {

--- a/eslint-plugin-expensify/no-negated-variables.js
+++ b/eslint-plugin-expensify/no-negated-variables.js
@@ -7,7 +7,7 @@ const message = require('./CONST').MESSAGE.NO_NEGATED_VARIABLES;
  * @returns {Boolean}
  */
 function isFalsePositive(string) {
-    const matches = /(.*)[nN](?:otification|otch|ote)(.*)/gm.exec(string);
+    const matches = /(.*?)(?:[nN](?:otification|otch|ote))+(.*)/gm.exec(string);
 
     if (!matches) {
         return false;

--- a/eslint-plugin-expensify/no-negated-variables.js
+++ b/eslint-plugin-expensify/no-negated-variables.js
@@ -7,7 +7,20 @@ const message = require('./CONST').MESSAGE.NO_NEGATED_VARIABLES;
  * @returns {Boolean}
  */
 function isFalsePositive(string) {
-    return _.some(['notification', 'notch'], falsePositive => string.toLowerCase().includes(falsePositive));
+    const matches = /(.*)[nN](?:otification|otch|ote)(.*)/gm.exec(string);
+
+    if (!matches) {
+        return false;
+    }
+
+    const prefix = matches[1];
+    const suffix = matches[2];
+
+    if (_.some([prefix, suffix], s => /.*[nN](?:ot).*/.test(s))) {
+        return false;
+    }
+
+    return true;
 }
 
 /**

--- a/eslint-plugin-expensify/tests/no-negated-variables.test.js
+++ b/eslint-plugin-expensify/tests/no-negated-variables.test.js
@@ -44,6 +44,9 @@ ruleTester.run('no-negated-variables', rule, {
         {
             code: 'const notionsOfNote = [];',
         },
+        {
+            code: 'const NOTABLE_EXCEPTIONS = [];',
+        },
     ],
     invalid: [
         {

--- a/eslint-plugin-expensify/tests/no-negated-variables.test.js
+++ b/eslint-plugin-expensify/tests/no-negated-variables.test.js
@@ -70,5 +70,11 @@ ruleTester.run('no-negated-variables', rule, {
                 message,
             }],
         },
+        {
+            code: 'const notificationNoteIsNotVisible = false',
+            errors: [{
+                message,
+            }],
+        },
     ],
 });

--- a/eslint-plugin-expensify/tests/no-negated-variables.test.js
+++ b/eslint-plugin-expensify/tests/no-negated-variables.test.js
@@ -23,6 +23,15 @@ ruleTester.run('no-negated-variables', rule, {
         {
             code: 'const iPhonesWithNotches = [];',
         },
+        {
+            code: 'const myNote = []',
+        },
+        {
+            code: 'const isNotification = {};',
+        },
+        {
+            code: 'const notificationIsVisible = false;',
+        }
     ],
     invalid: [
         {
@@ -37,5 +46,23 @@ ruleTester.run('no-negated-variables', rule, {
                 message,
             }],
         },
+        {
+            code: 'const isNotEnabled = false;',
+            errors: [{
+                message,
+            }],
+        },
+        {
+            code: 'const isNotChanged = false;',
+            errors: [{
+                message,
+            }],
+        },
+        {
+            code: 'const isNotNotification = false;',
+            errors: [{
+                message,
+            }],
+        }
     ],
 });

--- a/eslint-plugin-expensify/tests/no-negated-variables.test.js
+++ b/eslint-plugin-expensify/tests/no-negated-variables.test.js
@@ -38,6 +38,12 @@ ruleTester.run('no-negated-variables', rule, {
         {
             code: 'const notificationNote = {}',
         },
+        {
+            code: 'const notableNotions = [];',
+        },
+        {
+            code: 'const notionsOfNote = [];',
+        },
     ],
     invalid: [
         {

--- a/eslint-plugin-expensify/tests/no-negated-variables.test.js
+++ b/eslint-plugin-expensify/tests/no-negated-variables.test.js
@@ -31,7 +31,13 @@ ruleTester.run('no-negated-variables', rule, {
         },
         {
             code: 'const notificationIsVisible = false;',
-        }
+        },
+        {
+            code: 'const noteNotification = {}',
+        },
+        {
+            code: 'const notificationNote = {}',
+        },
     ],
     invalid: [
         {
@@ -63,6 +69,6 @@ ruleTester.run('no-negated-variables', rule, {
             errors: [{
                 message,
             }],
-        }
+        },
     ],
 });

--- a/eslint-plugin-expensify/tests/no-negated-variables.test.js
+++ b/eslint-plugin-expensify/tests/no-negated-variables.test.js
@@ -71,13 +71,31 @@ ruleTester.run('no-negated-variables', rule, {
             }],
         },
         {
+            code: 'const canNotBeValid = true;',
+            errors: [{
+                message,
+            }],
+        },
+        {
+            code: 'const willNotBeValid = true',
+            errors: [{
+                message,
+            }],
+        },
+        {
             code: 'const isNotNotification = false;',
             errors: [{
                 message,
             }],
         },
         {
-            code: 'const notificationNoteIsNotVisible = false',
+            code: 'const notificationNoteIsNotVisible = false;',
+            errors: [{
+                message,
+            }],
+        },
+        {
+            code: 'const notificationsThatAreNotOfNote = [];',
             errors: [{
                 message,
             }],

--- a/eslint-plugin-expensify/tests/no-negated-variables.test.js
+++ b/eslint-plugin-expensify/tests/no-negated-variables.test.js
@@ -103,5 +103,11 @@ ruleTester.run('no-negated-variables', rule, {
                 message,
             }],
         },
+        {
+            code: 'const THIS_IS_NOT_GOOD = true;',
+            errors: [{
+                message,
+            }],
+        },
     ],
 });


### PR DESCRIPTION
I found some cases that were incorrectly covered by this rule (namely, variables including the word `note`). I also made this more robust to catch a few more true positives, even if the variable includes one of the whitelisted words.