### PR TITLE
Enable no multiple empty lines rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-expensify",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-expensify",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "description": "Expensify's ESLint configuration following our style guide",
   "main": "index.js",
   "repository": {

--- a/rules/style.js
+++ b/rules/style.js
@@ -66,6 +66,7 @@ module.exports = {
             ],
             allowSamePrecedence: false,
         }],
+        'no-multiple-empty-lines': ['error', {'max': 1}],
         'no-plusplus': 'off',
         'no-return-assign': 'off',
         'object-curly-spacing': ['error', 'never'],


### PR DESCRIPTION
## Problem
PRs for Expensify/App often have extra unnecessary empty lines.
Some examples - https://github.com/Expensify/App/pull/8059#discussion_r823156399, https://github.com/Expensify/App/pull/7660#discussion_r817877880

## Solution
This PR enables the `no-multiple-empty-lines` rule, which will throw a lint error when more than 1 consecutive empty line is used. 

Reference: https://eslint.org/docs/rules/no-multiple-empty-lines

