### PR TITLE
Enforce no multiple empty lines

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -15,6 +15,7 @@ module.exports = {
         'react/prefer-es6-class': 'error',
         'react/prefer-stateless-function': 'error',
         'react/prop-types': 'error',
+        'react/jsx-props-no-multi-spaces': 'off',
         'react/no-find-dom-node': 'error',
         'react/forbid-prop-types': 'error',
         'react/no-string-refs': 'error',

--- a/rules/style.js
+++ b/rules/style.js
@@ -51,6 +51,7 @@ module.exports = {
             allowArrayStart: true,
             allowClassStart: true,
         }],
+        'no-multiple-empty-lines': ['error', {max: 1}],
         'max-len': ['warn', {
             code: 190,
         }],


### PR DESCRIPTION
This PR introduces two config changes:

1. Prevents multiple blank lines in a row. I've seen this come up in a few recent reviews.
1. Disables the `react/jsx-props-no-multi-spaces` rule, that complains about comments in jsx props:

### Before
```jsx
<MyComponent
    someProp
    
    // Some comment about a prop's usage
    // eslint-disable-next-line react/jsx-props-no-multi-spaces
    someOtherProps
/>
```

### After
```jsx
<MyComponent
    someProp
    
    // Some comment about a prop's usage
    someOtherProps
/>
```