### PR TITLE
Bump package version to 2.0.25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-expensify",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-expensify",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "Expensify's ESLint configuration following our style guide",
   "main": "index.js",
   "repository": {

--- a/rules/style.js
+++ b/rules/style.js
@@ -67,7 +67,6 @@ module.exports = {
             ],
             allowSamePrecedence: false,
         }],
-        'no-multiple-empty-lines': ['error', {'max': 1}],
         'no-plusplus': 'off',
         'no-return-assign': 'off',
         'object-curly-spacing': ['error', 'never'],


### PR DESCRIPTION
@rushatgabhane and I created two very similar PRs at almost the same time, with the same version numbers:

https://github.com/Expensify/eslint-config-expensify/pull/45
https://github.com/Expensify/eslint-config-expensify/pull/47

As a result, @rushatgabhane's PR was deployed and mine was not. However, there was a difference in that mine also added `'react/jsx-props-no-multi-spaces': 'off',`.

So this PR does two things:

1. Removes the redundant `no-multiple-empty-lines` rule
1. Bumps the package version so I can republish it with `jsx-props-no-multi-spaces`
