### PR TITLE
Create no-multiple-api-calls rule

### DIFF
--- a/eslint-plugin-expensify/CONST.js
+++ b/eslint-plugin-expensify/CONST.js
@@ -13,6 +13,6 @@ module.exports = {
         PREFER_STR_METHOD: 'Prefer \'Str.{{method}}\' over the native function.',
 
         // eslint-disable-next-line max-len
-        NO_MULTIPLE_API_CALLS: 'Do not call API or deprecatedAPI multiple times in the same method. The API response should return all the necessary data in a single request, and API calls should not be chained together.',
+        NO_MULTIPLE_API_CALLS: 'Do not call API or DeprecatedAPI multiple times in the same method. The API response should return all the necessary data in a single request, and API calls should not be chained together.',
     },
 };

--- a/eslint-plugin-expensify/CONST.js
+++ b/eslint-plugin-expensify/CONST.js
@@ -11,6 +11,8 @@ module.exports = {
         PREFER_ONYX_CONNECT_IN_LIBS: 'Only call Onyx.connect() from inside a /src/libs/** file. React components and non-library code should not use Onyx.connect()',
         PREFER_UNDERSCORE_METHOD: 'Prefer \'_.{{method}}\' over the native function.',
         PREFER_STR_METHOD: 'Prefer \'Str.{{method}}\' over the native function.',
-        NO_MULTIPLE_API_CALLS: 'Do not call API or deprecatedAPI multiple times in the same method. The API response should return all the necessary data in a single request.',
+
+        // eslint-disable-next-line max-len
+        NO_MULTIPLE_API_CALLS: 'Do not call API or deprecatedAPI multiple times in the same method. The API response should return all the necessary data in a single request, and API calls should not be chained together.',
     },
 };

--- a/eslint-plugin-expensify/CONST.js
+++ b/eslint-plugin-expensify/CONST.js
@@ -10,5 +10,6 @@ module.exports = {
         PREFER_IMPORT_MODULE_CONTENTS: 'Do not import individual exports from local modules. Prefer \'import * as\' syntax.',
         PREFER_ONYX_CONNECT_IN_LIBS: 'Only call Onyx.connect() from inside a /src/libs/** file. React components and non-library code should not use Onyx.connect()',
         PREFER_UNDERSCORE_METHOD: 'Prefer \'_.{{method}}\' over the native function.',
+        NO_MULTIPLE_API_CALLS: 'Do not call API or deprecatedAPI multiple times in the same method. The API response should return all the necessary data in a single request.',
     },
 };

--- a/eslint-plugin-expensify/no-api-in-views.js
+++ b/eslint-plugin-expensify/no-api-in-views.js
@@ -12,7 +12,7 @@ module.exports = {
                 return;
             }
 
-            if (node.name !== 'API') {
+            if (node.name !== 'API' && node.name !== 'deprecatedAPI') {
                 return;
             }
 

--- a/eslint-plugin-expensify/no-api-in-views.js
+++ b/eslint-plugin-expensify/no-api-in-views.js
@@ -12,7 +12,7 @@ module.exports = {
                 return;
             }
 
-            if (node.name !== 'API' && node.name !== 'deprecatedAPI') {
+            if (node.name !== 'API' && node.name !== 'DeprecatedAPI') {
                 return;
             }
 

--- a/eslint-plugin-expensify/no-multiple-api-calls.js
+++ b/eslint-plugin-expensify/no-multiple-api-calls.js
@@ -1,3 +1,4 @@
+const _ = require('underscore');
 const {isInActionFile} = require('./utils');
 const message = require('./CONST').MESSAGE.NO_MULTIPLE_API_CALLS;
 
@@ -13,21 +14,23 @@ module.exports = {
             const tokens = context.getSourceCode().getTokens(node);
             let hasCalledAPI = false;
 
-            for (let i = 0; i < tokens.length; i++) {
-                const token = tokens[i];
+            _.each(tokens, (token) => {
                 const isAPICall = token.value === 'deprecatedAPI' || token.value === 'API';
 
-                if (isAPICall && hasCalledAPI) {
-                    context.report({
-                        node: token,
-                        message,
-                    });
+                if (!isAPICall) {
+                    return;
                 }
 
-                if (isAPICall && !hasCalledAPI) {
+                if (!hasCalledAPI) {
                     hasCalledAPI = true;
+                    return;
                 }
-            }
+
+                context.report({
+                    node: token,
+                    message,
+                });
+            });
         }
 
         return {

--- a/eslint-plugin-expensify/no-multiple-api-calls.js
+++ b/eslint-plugin-expensify/no-multiple-api-calls.js
@@ -1,24 +1,40 @@
+const {isInActionFile} = require('./utils');
 const message = require('./CONST').MESSAGE.NO_MULTIPLE_API_CALLS;
 
 module.exports = {
     create(context) {
-        let count = 0;
         function checkFunctionBody(node) {
-            if (node.name === 'deprecatedAPI' || node.name === 'API') {
-                count++;
-                if (count > 1) {
-                    context.report({
-                        node,
-                        message,
-                    });
+            // This rule is scoped to the ./actions/ directory because we already have a rule
+            // preventing any API calls outside of actions.
+            if (!isInActionFile(context.getFilename())) {
+                return;
+            }
+
+            const tokens = context.getSourceCode().getTokens(node);
+            let hasCalledAPI = false;
+
+            for (let i = 0; i < tokens.length; i++) {
+                const token = tokens[i];
+                if (token.value !== 'deprecatedAPI' && token.value !== 'API') {
+                    continue;
                 }
+
+                if (!hasCalledAPI) {
+                    hasCalledAPI = true;
+                    continue;
+                }
+
+                context.report({
+                    node: token,
+                    message,
+                });
             }
         }
 
         return {
-            "FunctionDeclaration CallExpression Identifier": checkFunctionBody,
-            "FunctionExpression CallExpression Identifier": checkFunctionBody,
-            "ArrowFunctionExpression CallExpression Identifier": checkFunctionBody,
+            FunctionDeclaration: checkFunctionBody,
+            FunctionExpression: checkFunctionBody,
+            ArrowFunctionExpression: checkFunctionBody,
         };
     },
 };

--- a/eslint-plugin-expensify/no-multiple-api-calls.js
+++ b/eslint-plugin-expensify/no-multiple-api-calls.js
@@ -8,7 +8,7 @@ module.exports = {
             let hasCalledAPI = false;
 
             _.each(tokens, (token) => {
-                const isAPICall = token.value === 'deprecatedAPI' || token.value === 'API';
+                const isAPICall = token.value === 'DeprecatedAPI' || token.value === 'API';
 
                 if (!isAPICall) {
                     return;

--- a/eslint-plugin-expensify/no-multiple-api-calls.js
+++ b/eslint-plugin-expensify/no-multiple-api-calls.js
@@ -1,16 +1,9 @@
 const _ = require('underscore');
-const {isInActionFile} = require('./utils');
 const message = require('./CONST').MESSAGE.NO_MULTIPLE_API_CALLS;
 
 module.exports = {
     create(context) {
         function checkFunctionBody(node) {
-            // This rule is scoped to the ./actions/ directory because we already have a rule
-            // preventing any API calls outside of actions.
-            if (!isInActionFile(context.getFilename())) {
-                return;
-            }
-
             const tokens = context.getSourceCode().getTokens(node);
             let hasCalledAPI = false;
 

--- a/eslint-plugin-expensify/no-multiple-api-calls.js
+++ b/eslint-plugin-expensify/no-multiple-api-calls.js
@@ -15,19 +15,18 @@ module.exports = {
 
             for (let i = 0; i < tokens.length; i++) {
                 const token = tokens[i];
-                if (token.value !== 'deprecatedAPI' && token.value !== 'API') {
-                    continue;
+                const isAPICall = token.value === 'deprecatedAPI' || token.value === 'API';
+
+                if (isAPICall && hasCalledAPI) {
+                    context.report({
+                        node: token,
+                        message,
+                    });
                 }
 
-                if (!hasCalledAPI) {
+                if (isAPICall && !hasCalledAPI) {
                     hasCalledAPI = true;
-                    continue;
                 }
-
-                context.report({
-                    node: token,
-                    message,
-                });
             }
         }
 

--- a/eslint-plugin-expensify/no-multiple-api-calls.js
+++ b/eslint-plugin-expensify/no-multiple-api-calls.js
@@ -1,0 +1,8 @@
+const lodashGet = require('lodash/get');
+const message = require('./CONST').MESSAGE.NO_MULTIPLE_API_CALLS;
+
+module.exports = {
+    create: context => ({
+        // check for multiple api calls in one method
+    }),
+};

--- a/eslint-plugin-expensify/no-multiple-api-calls.js
+++ b/eslint-plugin-expensify/no-multiple-api-calls.js
@@ -1,8 +1,24 @@
-const lodashGet = require('lodash/get');
 const message = require('./CONST').MESSAGE.NO_MULTIPLE_API_CALLS;
 
 module.exports = {
-    create: context => ({
-        // check for multiple api calls in one method
-    }),
+    create(context) {
+        let count = 0;
+        function checkFunctionBody(node) {
+            if (node.name === 'deprecatedAPI' || node.name === 'API') {
+                count++;
+                if (count > 1) {
+                    context.report({
+                        node,
+                        message,
+                    });
+                }
+            }
+        }
+
+        return {
+            "FunctionDeclaration CallExpression Identifier": checkFunctionBody,
+            "FunctionExpression CallExpression Identifier": checkFunctionBody,
+            "ArrowFunctionExpression CallExpression Identifier": checkFunctionBody,
+        };
+    },
 };

--- a/eslint-plugin-expensify/no-negated-variables.js
+++ b/eslint-plugin-expensify/no-negated-variables.js
@@ -43,7 +43,7 @@ function isFalsePositive(string) {
     const isSuffixNegatedVariableName = isNegatedVariableName(suffix);
 
     return !isPrefixNegatedVariableName && !isSuffixNegatedVariableName;
-};
+}
 
 /**
  * @param {String} name
@@ -56,7 +56,7 @@ function isNegatedVariableName(name) {
 
     return _.any(BANNED_SUBSTRINGS, badSubstring => name.toLowerCase().includes(badSubstring))
         && !isFalsePositive(name);
-};
+}
 
 module.exports = {
     create: context => ({

--- a/eslint-plugin-expensify/tests/no-api-in-views.test.js
+++ b/eslint-plugin-expensify/tests/no-api-in-views.test.js
@@ -10,6 +10,7 @@ const ruleTester = new RuleTester({
 });
 
 const example = 'API.signIn();';
+const example2 = 'deprecatedAPI.signIn();';
 
 ruleTester.run('no-api-in-views', rule, {
     valid: [
@@ -19,10 +20,23 @@ ruleTester.run('no-api-in-views', rule, {
             // Mock filename - it's acceptable to use API in an action file, but not component
             filename: './src/libs/actions/Test.js',
         },
+        {
+            code: example2,
+
+            // Mock filename - it's acceptable to use API in an action file, but not component
+            filename: './src/libs/actions/Test.js',
+        },
     ],
     invalid: [
         {
             code: example,
+            errors: [{
+                message,
+            }],
+            filename: './src/components/Test.js',
+        },
+        {
+            code: example2,
             errors: [{
                 message,
             }],

--- a/eslint-plugin-expensify/tests/no-api-in-views.test.js
+++ b/eslint-plugin-expensify/tests/no-api-in-views.test.js
@@ -10,7 +10,7 @@ const ruleTester = new RuleTester({
 });
 
 const example = 'API.signIn();';
-const example2 = 'deprecatedAPI.signIn();';
+const example2 = 'DeprecatedAPI.User_IsUsingExpensifyCard();';
 
 ruleTester.run('no-api-in-views', rule, {
     valid: [

--- a/eslint-plugin-expensify/tests/no-api-in-views.test.js
+++ b/eslint-plugin-expensify/tests/no-api-in-views.test.js
@@ -22,8 +22,6 @@ ruleTester.run('no-api-in-views', rule, {
         },
         {
             code: example2,
-
-            // Mock filename - it's acceptable to use API in an action file, but not component
             filename: './src/libs/actions/Test.js',
         },
     ],

--- a/eslint-plugin-expensify/tests/no-multiple-api-calls.test.js
+++ b/eslint-plugin-expensify/tests/no-multiple-api-calls.test.js
@@ -1,5 +1,5 @@
 const RuleTester = require('eslint').RuleTester;
-const rule = require('../no-api-in-views');
+const rule = require('../no-multiple-api-calls');
 const message = require('../CONST').MESSAGE.NO_MULTIPLE_API_CALLS;
 
 const ruleTester = new RuleTester({
@@ -9,6 +9,9 @@ const ruleTester = new RuleTester({
     },
 });
 
+// Mock filename - this rule is scoped to the ./actions/ directory.
+const filename = './src/libs/actions/Test.js';
+
 ruleTester.run('no-multiple-api-calls', rule, {
     valid: [
         {
@@ -17,9 +20,7 @@ ruleTester.run('no-multiple-api-calls', rule, {
                     API.call(params);
                 }
             `,
-
-            // Mock filename - it's acceptable to use API in an action file, but not component
-            filename: './src/libs/actions/Test.js',
+            filename,
         },
         {
             code: `
@@ -27,7 +28,7 @@ ruleTester.run('no-multiple-api-calls', rule, {
                     deprecatedAPI.call(params);
                 }
             `,
-            filename: './src/libs/actions/Test.js',
+            filename,
         },
     ],
     invalid: [
@@ -40,7 +41,7 @@ ruleTester.run('no-multiple-api-calls', rule, {
             errors: [{
                 message,
             }],
-            filename: './src/libs/actions/Test.js',
+            filename,
         },
     ],
 });

--- a/eslint-plugin-expensify/tests/no-multiple-api-calls.test.js
+++ b/eslint-plugin-expensify/tests/no-multiple-api-calls.test.js
@@ -9,9 +9,6 @@ const ruleTester = new RuleTester({
     },
 });
 
-// Mock filename - this rule is scoped to the ./actions/ directory.
-const filename = './src/libs/actions/Test.js';
-
 ruleTester.run('no-multiple-api-calls', rule, {
     valid: [
         {
@@ -20,7 +17,6 @@ ruleTester.run('no-multiple-api-calls', rule, {
                     API.call(params);
                 }
             `,
-            filename,
         },
         {
             code: `
@@ -28,7 +24,6 @@ ruleTester.run('no-multiple-api-calls', rule, {
                     deprecatedAPI.call(params);
                 }
             `,
-            filename,
         },
     ],
     invalid: [
@@ -41,7 +36,6 @@ ruleTester.run('no-multiple-api-calls', rule, {
             errors: [{
                 message,
             }],
-            filename,
         },
     ],
 });

--- a/eslint-plugin-expensify/tests/no-multiple-api-calls.test.js
+++ b/eslint-plugin-expensify/tests/no-multiple-api-calls.test.js
@@ -14,14 +14,14 @@ ruleTester.run('no-multiple-api-calls', rule, {
         {
             code: `
                 function test() {
-                    API.call(params);
+                    API.write('Report_AddComment', params);
                 }
             `,
         },
         {
             code: `
                 function test() {
-                    deprecatedAPI.call(params);
+                    DeprecatedAPI.CreateLogin(params);
                 }
             `,
         },
@@ -30,7 +30,7 @@ ruleTester.run('no-multiple-api-calls', rule, {
         {
             code: `
                 function test() {
-                    deprecatedAPI.call(params).then(res => API.call(params2));
+                    DeprecatedAPI.CreateLogin(params).then(res => API.write('PreferredLocale_Update', params2));
                 }
             `,
             errors: [{

--- a/eslint-plugin-expensify/tests/no-multiple-api-cals.test.js
+++ b/eslint-plugin-expensify/tests/no-multiple-api-cals.test.js
@@ -1,0 +1,46 @@
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../no-api-in-views');
+const message = require('../CONST').MESSAGE.NO_MULTIPLE_API_CALLS;
+
+const ruleTester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module',
+    },
+});
+
+ruleTester.run('no-multiple-api-calls', rule, {
+    valid: [
+        {
+            code: `
+                function test() {
+                    API.call(params);
+                }
+            `,
+
+            // Mock filename - it's acceptable to use API in an action file, but not component
+            filename: './src/libs/actions/Test.js',
+        },
+        {
+            code: `
+                function test() {
+                    deprecatedAPI.call(params);
+                }
+            `,
+            filename: './src/libs/actions/Test.js',
+        },
+    ],
+    invalid: [
+        {
+            code: `
+                function test() {
+                    deprecatedAPI.call(params).then(res => API.call(params2));
+                }
+            `,
+            errors: [{
+                message,
+            }],
+            filename: './src/libs/actions/Test.js',
+        },
+    ],
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-expensify",
-  "version": "2.0.26",
+  "version": "2.0.27",
   "description": "Expensify's ESLint configuration following our style guide",
   "main": "index.js",
   "repository": {

--- a/rules/expensify.js
+++ b/rules/expensify.js
@@ -12,11 +12,11 @@ module.exports = {
         'rulesdir/prefer-import-module-contents': 'error',
         'rulesdir/no-multiple-api-calls': 'error',
         'no-restricted-imports': ['error', {
-            'paths': [{
-                'name': 'react-native',
-                'importNames': ['Button', 'Text', 'TextInput', 'Picker'],
-                'message': 'Please use an Expensify component from src/components/ instead.'
-            }]
-        }]
+            paths: [{
+                name: 'react-native',
+                importNames: ['Button', 'Text', 'TextInput', 'Picker'],
+                message: 'Please use an Expensify component from src/components/ instead.',
+            }],
+        }],
     },
 };

--- a/rules/expensify.js
+++ b/rules/expensify.js
@@ -10,6 +10,7 @@ module.exports = {
         'rulesdir/prefer-underscore-method': 'error',
         'rulesdir/no-useless-compose': 'error',
         'rulesdir/prefer-import-module-contents': 'error',
+        'rulesdir/no-multiple-api-calls': 'error',
         'no-restricted-imports': ['error', {
             'paths': [{
                 'name': 'react-native',

--- a/rules/style.js
+++ b/rules/style.js
@@ -38,6 +38,7 @@ module.exports = {
             flatTernaryExpressions: false,
 
             // list derived from https://github.com/benjamn/ast-types/blob/HEAD/def/jsx.js
+            // eslint-disable-next-line max-len
             ignoredNodes: ['JSXElement', 'JSXElement > *', 'JSXAttribute', 'JSXIdentifier', 'JSXNamespacedName', 'JSXMemberExpression', 'JSXSpreadAttribute', 'JSXExpressionContainer', 'JSXOpeningElement', 'JSXClosingElement', 'JSXText', 'JSXEmptyExpression', 'JSXSpreadChild'],
             ignoreComments: false,
         }],


### PR DESCRIPTION
- Implements `no-multiple-api-calls` rule.
- Adds `deprecatedAPI` to `no-api-in-views` and update tests.
- Fixes lint errors in other files.

# Issue
Fixes https://github.com/Expensify/Expensify/issues/211243

# Tests
1. Ran `npm run test` and make sure all tests pass.
