### PR TITLE
feat: add rule onyx-props-must-have-default

### DIFF
--- a/eslint-plugin-expensify/CONST.js
+++ b/eslint-plugin-expensify/CONST.js
@@ -18,5 +18,12 @@ module.exports = {
         NO_MULTIPLE_API_CALLS: 'Do not call API multiple times in the same method. The API response should return all the necessary data in a single request, and API calls should not be chained together.',
         NO_CALL_ACTIONS_FROM_ACTIONS: 'Calling actions from inside other actions is forbidden. If an action needs to call another action combine the two actions into a singular API call instead.',
         NO_API_SIDE_EFFECTS_METHOD: 'Do not use makeRequestWithSideEffects.',
+        PROP_TYPE_REQUIRED_FALSE: 'Prop {{key}} should not be explicily required.',
+        PROP_TYPE_NOT_DECLARED: 'Prop {{key}} must be declared in propTypes.',
+        PROP_DEEFAULT_NOT_DECLARED: 'Prop {{key}} must have a default value.',
+        HAVE_PROP_TYPES: 'Component must have prop types declared.',
+        HAVE_DEFAULT_PROPS: 'Component must have default prop values.',
+        ONYX_ONE_PARAM: 'The withOnyx HOC must be passed at least one argument.',
+        MUST_USE_VARIABLE_FOR_ASSIGNMENT: '{{key}} must be assigned as a variable instead of direct assignment.',
     },
 };

--- a/eslint-plugin-expensify/onyx-props-must-have-default.js
+++ b/eslint-plugin-expensify/onyx-props-must-have-default.js
@@ -1,0 +1,248 @@
+const _ = require('underscore');
+const lodashGet = require('lodash/get');
+const {parse} = require('babel-eslint');
+const path = require('path');
+const fs = require('fs');
+const {
+    PROP_TYPE_REQUIRED_FALSE, PROP_TYPE_NOT_DECLARED, PROP_DEEFAULT_NOT_DECLARED, HAVE_PROP_TYPES, HAVE_DEFAULT_PROPS, ONYX_ONE_PARAM, MUST_USE_VARIABLE_FOR_ASSIGNMENT,
+} = require('./CONST').MESSAGE;
+
+module.exports = {
+    create(context) {
+        // Report any issues
+        function makeReport(node, message, data = null) {
+            context.report({
+                node,
+                message,
+                data: {
+                    key: data,
+                },
+            });
+        }
+
+        // Check if a list of properties has a property using spread (...) operator
+        function hasSpreadOperator(node) {
+            return _.find(
+                node.init.properties,
+                n => (lodashGet(n, 'type') === 'ExperimentalSpreadProperty' || lodashGet(n, 'type') === 'SpreadElement'),
+            );
+        }
+
+        // Get the list of properties from an external file
+        function getExternalProperties(sourceFile, variableNode, type) {
+            const importedVariableValue = sourceFile;
+
+            // Need to append .js since file extension is not used in imports
+            const importedFile = `${path.resolve(path.dirname(context.getFilename()), importedVariableValue)}.js`;
+            let importedValue;
+            try {
+                const raw = fs.readFileSync(importedFile);
+                const ast = parse(raw.toString(), {sourceType: 'module'});
+                if (type === 'ImportSpecifier') {
+                    // If the import is of type - import {prop} from "./props"
+                    const variableName = variableNode.defs[0].node.imported.name;
+                    importedValue = _.find(
+                        ast.body,
+                        n => lodashGet(n, 'type') === 'VariableDeclaration'
+                            && lodashGet(n, 'declarations[0].id.name') === variableName,
+                    ).declarations[0].init.properties;
+                } else if (type === 'ImportDefaultSpecifier') {
+                    // If the import is of type - import prop from "./props"
+                    importedValue = _.find(
+                        ast.body,
+                        n => lodashGet(n, 'type') === 'ExportDefaultDeclaration',
+                    ).declaration.properties;
+                }
+            } catch (err) {
+                // If there are any issues parsing the code to AST.
+                // Can be ignored, it's impossible for the parsing to fail as long as the component code is correct
+                // console.log(err);
+            }
+            return importedValue;
+        }
+
+        // Get the variable node from the list of variable nodes
+        function getVariableNode(variables, name) {
+            return _.find(
+                variables,
+                v => lodashGet(v, 'name') === name,
+            );
+        }
+
+        // Get the node of the prop type declaration based on name
+        // For example: Component.propTypes = propTypes
+        function getPropsDeclaration(body, name) {
+            return _.find(
+                body,
+                n => lodashGet(n, 'type') === 'ExpressionStatement'
+                    && lodashGet(n, 'expression.left.property.name') === name,
+            );
+        }
+
+        // For each property making use of spread operator, get the properties from the variable
+        function getProperties(scope, propertiesVar) {
+            const resolvedProps = [];
+            _.each(
+                _.filter(
+                    propertiesVar,
+                    n => (lodashGet(n, 'type') === 'ExperimentalSpreadProperty' || lodashGet(n, 'type') === 'SpreadElement'),
+                ),
+                (prop) => {
+                    const variables = scope.variables;
+                    let variableNode = getVariableNode(variables, prop.argument.name);
+                    if (!variableNode) {
+                        // Required in case of HOCs like withPolicy, since they might have the prop types
+                        // declared outside the function, which is not in function scope
+                        variableNode = getVariableNode(scope.upper.variables, prop.argument.name);
+                    }
+
+                    if (variableNode.defs[0].type === 'ImportBinding') {
+                        // If the spread operator variable is imported
+                        const externalProps = getExternalProperties(variableNode.defs[0].node.parent.source.value, variableNode, variableNode.defs[0].node.type);
+                        resolvedProps.push(...externalProps);
+                    } else {
+                        // If the spread operator variable is in same file
+                        const internalProps = variableNode.defs[0].node.init.properties;
+                        resolvedProps.push(...internalProps);
+                    }
+                },
+            );
+            return resolvedProps;
+        }
+
+        // Get the final list of properties
+        function getPropsValue(scope, propsVar) {
+            const variables = scope.variables;
+            let props = getVariableNode(variables, propsVar);
+            if (!props) {
+                // Required in case of HOCs like withPolicy, since they might have the prop types
+                // declared outside the function, which is not in function scope
+                props = getVariableNode(scope.upper.variables, propsVar);
+            }
+
+            if (!propsVar || !props) {
+                return undefined;
+            }
+
+            // Need to check for existence of init since it is not present if the assignment is to an imported variable
+            let propsProperties;
+            if (props.defs[0].node.type === 'VariableDeclarator') {
+                // If the variable is an assignment
+                if (props.defs[0].node.init.type === 'ObjectExpression') {
+                    // let defaultProps = {....}
+                    propsProperties = props.defs[0].node.init && props.defs[0].node.init.properties;
+                } else if (props.defs[0].node.init.type === 'Identifier') {
+                    // let defaultProps = importedDefaultProps;
+                    return getPropsValue(scope, props.defs[0].node.init.name);
+                }
+
+                if (props.defs[0].type === 'ImportBinding') {
+                    propsProperties = getExternalProperties(props.defs[0].node.parent.source.value, props, props.defs[0].node.type);
+                } else if (hasSpreadOperator(props.defs[0].node)) {
+                    const resolvedProps = getProperties(scope, propsProperties);
+                    propsProperties = propsProperties.concat(resolvedProps);
+                }
+            } else if (props.defs[0].node.type === 'ImportSpecifier') {
+                // If the variable is a direct import
+                propsProperties = getExternalProperties(props.defs[0].node.parent.source.value, props, props.defs[0].node.type);
+            }
+
+            return propsProperties;
+        }
+
+        // Report and exit if direct assignment
+        // For example, Component.propType = {prop1: type1}
+        function isDirectAssignment(node, declaration, key) {
+            if (lodashGet(declaration, 'expression.right.type') === 'ObjectExpression') {
+                makeReport(node, MUST_USE_VARIABLE_FOR_ASSIGNMENT, key);
+                return 1;
+            }
+            return 0;
+        }
+
+        return {
+            CallExpression(node) {
+                const name = lodashGet(node, 'callee.name');
+                if (!name) {
+                    return;
+                }
+
+                if (name !== 'withOnyx') {
+                    return;
+                }
+
+                if (node.arguments.length === 0) {
+                    context.report({
+                        node,
+                        message: ONYX_ONE_PARAM,
+                    });
+                }
+
+                // Get all the tree ancestors
+                const ancestors = context.getAncestors();
+
+                // Check the component is an HOC that wraps a component
+                const wrappedComponent = _.find(
+                    ancestors,
+                    n => lodashGet(n, 'type') === 'ExportDefaultDeclaration'
+                        && lodashGet(n, 'declaration.params[0].name') === 'WrappedComponent',
+                );
+
+                let propTypesDeclaration; let
+                    defaultPropTypesDeclaration;
+                if (wrappedComponent) {
+                    propTypesDeclaration = getPropsDeclaration(wrappedComponent.declaration.body.body, 'propTypes');
+                    defaultPropTypesDeclaration = getPropsDeclaration(wrappedComponent.declaration.body.body, 'defaultProps');
+                } else {
+                    propTypesDeclaration = getPropsDeclaration(ancestors[0].body, 'propTypes');
+                    defaultPropTypesDeclaration = getPropsDeclaration(ancestors[0].body, 'defaultProps');
+                }
+
+                if (isDirectAssignment(node, propTypesDeclaration, 'propTypes') || isDirectAssignment(node, defaultPropTypesDeclaration, 'defaultProps')) {
+                    return;
+                }
+
+                const scope = context.getScope();
+
+                // Get the assigned variable name
+                const propTypesVar = lodashGet(propTypesDeclaration, 'expression.right.name');
+                const defaultPropsVar = lodashGet(defaultPropTypesDeclaration, 'expression.right.name');
+
+                // Get the list of properties
+                const propTypesProperties = getPropsValue(scope, propTypesVar);
+                const defaultPropsProperties = getPropsValue(scope, defaultPropsVar);
+
+                if (!propTypesProperties) {
+                    makeReport(node, HAVE_PROP_TYPES);
+                    return;
+                } if (!defaultPropsProperties) {
+                    makeReport(node, HAVE_DEFAULT_PROPS);
+                    return;
+                }
+
+                // Get the list of properties of withOnyx
+                const onyxProperties = lodashGet(node, 'arguments[0].properties');
+
+                _.forEach(onyxProperties, (property) => {
+                    const onyxKeyName = lodashGet(property, 'key.name');
+                    const declaredPropType = _.find(propTypesProperties, p => p.type === 'Property' && lodashGet(p, 'key.name') === onyxKeyName);
+                    const defaultPropType = _.find(defaultPropsProperties, p => p.type === 'Property' && lodashGet(p, 'key.name') === onyxKeyName);
+
+                    if (declaredPropType) {
+                        if (lodashGet(declaredPropType, 'value.type') === 'MemberExpression') {
+                            if (lodashGet(declaredPropType, 'value.property.name') === 'isRequired') {
+                                makeReport(node, PROP_TYPE_REQUIRED_FALSE, onyxKeyName);
+                            }
+                        }
+                    } else {
+                        makeReport(node, PROP_TYPE_NOT_DECLARED, onyxKeyName);
+                    }
+
+                    if (!defaultPropType) {
+                        makeReport(node, PROP_DEEFAULT_NOT_DECLARED, onyxKeyName);
+                    }
+                });
+            },
+        };
+    },
+};

--- a/eslint-plugin-expensify/onyx-props-must-have-default.js
+++ b/eslint-plugin-expensify/onyx-props-must-have-default.js
@@ -120,7 +120,7 @@ module.exports = {
                 props = getVariableNode(scope.upper.variables, propsVar);
             }
 
-            if (!propsVar || !props) {
+            if (!propsVar || !props || !lodashGet(props, 'defs[0]')) {
                 return undefined;
             }
 
@@ -155,9 +155,9 @@ module.exports = {
         function isDirectAssignment(node, declaration, key) {
             if (lodashGet(declaration, 'expression.right.type') === 'ObjectExpression') {
                 makeReport(node, MUST_USE_VARIABLE_FOR_ASSIGNMENT, key);
-                return 1;
+                return true;
             }
-            return 0;
+            return false;
         }
 
         return {
@@ -223,7 +223,7 @@ module.exports = {
                 // Get the list of properties of withOnyx
                 const onyxProperties = lodashGet(node, 'arguments[0].properties');
 
-                _.forEach(onyxProperties, (property) => {
+                _.each(onyxProperties, (property) => {
                     const onyxKeyName = lodashGet(property, 'key.name');
                     const declaredPropType = _.find(propTypesProperties, p => p.type === 'Property' && lodashGet(p, 'key.name') === onyxKeyName);
                     const defaultPropType = _.find(defaultPropsProperties, p => p.type === 'Property' && lodashGet(p, 'key.name') === onyxKeyName);

--- a/eslint-plugin-expensify/onyx-props-must-have-default.js
+++ b/eslint-plugin-expensify/onyx-props-must-have-default.js
@@ -188,8 +188,9 @@ module.exports = {
                         && lodashGet(n, 'declaration.params[0].name') === 'WrappedComponent',
                 );
 
-                let propTypesDeclaration; let
-                    defaultPropTypesDeclaration;
+                let propTypesDeclaration;
+                let defaultPropTypesDeclaration;
+
                 if (wrappedComponent) {
                     propTypesDeclaration = getPropsDeclaration(wrappedComponent.declaration.body.body, 'propTypes');
                     defaultPropTypesDeclaration = getPropsDeclaration(wrappedComponent.declaration.body.body, 'defaultProps');

--- a/eslint-plugin-expensify/tests/onyx-props-must-have-default.test.js
+++ b/eslint-plugin-expensify/tests/onyx-props-must-have-default.test.js
@@ -12,6 +12,7 @@ const ruleTester = new RuleTester({
         ecmaFeatures: {
             // To support use of < in HOC
             jsx: true,
+
             // To support use of ... operator
             experimentalObjectRestSpread: true,
         },

--- a/eslint-plugin-expensify/tests/onyx-props-must-have-default.test.js
+++ b/eslint-plugin-expensify/tests/onyx-props-must-have-default.test.js
@@ -1,0 +1,320 @@
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../onyx-props-must-have-default');
+
+const {
+    PROP_TYPE_REQUIRED_FALSE, PROP_TYPE_NOT_DECLARED, PROP_DEEFAULT_NOT_DECLARED, HAVE_PROP_TYPES, HAVE_DEFAULT_PROPS, ONYX_ONE_PARAM, MUST_USE_VARIABLE_FOR_ASSIGNMENT,
+} = require('../CONST');
+
+const ruleTester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 2018,
+        sourceType: 'module',
+        ecmaFeatures: {
+            // To support use of < in HOC
+            jsx: true,
+            // To support use of ... operator
+            experimentalObjectRestSpread: true,
+        },
+    },
+});
+
+ruleTester.run('onyx-props-must-have-default', rule, {
+    invalid: [
+        // onyxProp has isRequired
+        {
+            code: `
+            const defaultProps = {
+                propKey: false,
+            };
+            
+            Component.defaultProps = defaultProps;
+            export default withOnyx({
+                propKey: {
+                    key: ONYXKEYS.key,
+                },
+            })(Component);
+            `,
+            errors: [{
+                HAVE_PROP_TYPES,
+            }],
+        },
+        {
+            code: `
+            const propTypes = {
+                propKey: PropTypes.bool,
+            };
+            
+            Component.propTypes = propTypes;
+            export default withOnyx({
+                propKey: {
+                    key: ONYXKEYS.key,
+                },
+            })(Component);
+            `,
+            errors: [{
+                HAVE_DEFAULT_PROPS,
+            }],
+        },
+        {
+            code: `
+            const propTypes = {
+                propKey: PropTypes.bool.isRequired,
+            };
+            
+            const defaultProps = {
+                propKey: false,
+            };
+            
+            Component.propTypes = propTypes;
+            Component.defaultProps = defaultProps;
+            export default withOnyx({
+                propKey: {
+                    key: ONYXKEYS.key,
+                },
+            })(Component);
+            `,
+            errors: [{
+                PROP_TYPE_REQUIRED_FALSE,
+            }],
+        },
+        {
+            code: `
+            const propTypes = {
+                randomProp: PropTypes.bool,
+            };
+            
+            const defaultProps = {
+                randomProp: false,
+            };
+            
+            Component.propTypes = propTypes;
+            Component.defaultProps = defaultProps;
+            export default withOnyx({
+                propKey: {
+                    key: ONYXKEYS.key,
+                },
+            })(Component);
+            `,
+            errors: [
+                {
+                    PROP_TYPE_NOT_DECLARED,
+                },
+                {
+                    PROP_DEEFAULT_NOT_DECLARED,
+                },
+            ],
+        },
+        {
+            code: `
+            const propTypes = {
+                propKey: PropTypes.bool,
+            };
+            
+            const defaultProps = {
+                propKey: false,
+            };
+            
+            Component.propTypes = propTypes;
+            Component.defaultProps = defaultProps;
+            export default withOnyx()(Component);
+            `,
+            errors: [{
+                ONYX_ONE_PARAM,
+            }],
+        },
+        {
+            code: `
+            Component.propTypes = {
+                propKey: PropTypes.bool,
+            };
+            Component.defaultProps = {
+                propKey: false,
+            };
+            export default withOnyx({
+                propKey: {
+                    key: ONYXKEYS.key,
+                },
+            })(Component);
+            `,
+            errors: [{
+                MUST_USE_VARIABLE_FOR_ASSIGNMENT,
+            }],
+        },
+    ],
+    valid: [
+        {
+            code: `
+            const propTypes = {
+                propKey: PropTypes.bool,
+            };
+            
+            const defaultProps = {
+                propKey: false,
+            };
+            
+            Component.propTypes = propTypes;
+            Component.defaultProps = defaultProps;
+            export default withOnyx({
+                propKey: {
+                    key: ONYXKEYS.key,
+                },
+            })(Component);`,
+        },
+        {
+            code: `
+            const propTypes = {
+                propKey: PropTypes.bool,
+            };
+            
+            const defaultProps = {
+                propKey: false,
+            };
+            
+            Component.propTypes = propTypes;
+            Component.defaultProps = defaultProps;
+            export default compose(
+                withOnyx({
+                    propKey: {
+                        key: ONYXKEYS.key,
+                    },
+                }),
+            )(Component);`,
+        },
+        {
+            code: `
+            import {samplePropTypes, sampleDefaultProps} from "./sample-props";
+
+            Component.propTypes = samplePropTypes;
+            Component.defaultProps = sampleDefaultProps;
+            export default withOnyx({
+                propKey: {
+                    key: ONYXKEYS.key,
+                },
+            })(Component);`,
+        },
+        {
+            code: `
+            import {samplePropTypes, sampleDefaultProps} from "./sample-props";
+
+            const propTypes = samplePropTypes;
+            const defaultProps = sampleDefaultProps;
+
+            Component.propTypes = propTypes;
+            Component.defaultProps = defaultProps;
+            export default withOnyx({
+                propKey: {
+                    key: ONYXKEYS.key,
+                },
+            })(Component);`,
+        },
+        {
+            code: `
+            import {samplePropTypes, sampleDefaultProps} from "./sample-props";
+
+            const propTypes = {
+                ...samplePropTypes,
+            };
+
+            const defaultProps = {
+                ...sampleDefaultProps,
+            };
+
+            Component.propTypes = propTypes;
+            Component.defaultProps = defaultProps;
+            export default withOnyx({
+                propKey: {
+                    key: ONYXKEYS.key,
+                },
+            })(Component);`,
+        },
+        {
+            code: `
+            import * as sampleProps from "./sample-props";
+
+            const propTypes = {
+                propKey: sampleProps.samplePropTypes,
+            };
+            
+            const defaultProps = {
+                propKey: sampleProps.sampleDefaultProps,
+            };
+
+            Component.propTypes = propTypes;
+            Component.defaultProps = defaultProps;
+            export default withOnyx({
+                propKey: {
+                    key: ONYXKEYS.key,
+                },
+            })(Component);`,
+        },
+        {
+            code: `
+            export default function (WrappedComponent) {
+                const propTypes = {
+                    propKey: PropTypes.bool
+                };
+            
+                const defaultProps = {
+                    propKey: false,
+                };
+            
+                const WithHOC = (props) => {
+                    const extraProp = props.randomProp;
+            
+                    return (
+                        <WrappedComponent
+                            {...props}
+                        />
+                    );
+                };
+            
+                WithHOC.propTypes = propTypes;
+                WithHoc.defaultProps = defaultProps;
+            
+                return withOnyx({
+                    propKey: {
+                        key: ONYXKEYS.key,
+                    }
+                })
+            }`,
+        },
+        {
+            code: `
+            const hocPropTypes = {
+                propKey: PropTypes.bool,
+            };
+            
+            const hocDefaultProps = {
+                propKey: false,
+            }
+            export default function (WrappedComponent) {
+                const propTypes = {
+                    ...hocPropTypes
+                };
+            
+                const defaultProps = {
+                    ...hocDefaultProps,
+                };
+            
+                const WithHOC = (props) => {
+                    const extraProp = props.randomProp;
+            
+                    return (
+                        <WrappedComponent
+                            {...props}
+                        />
+                    );
+                };
+            
+                WithHOC.propTypes = propTypes;
+                WithHoc.defaultProps = defaultProps;
+            
+                return withOnyx({
+                    propKey: {
+                        key: ONYXKEYS.key,
+                    }
+                })
+            }`,
+        },
+    ],
+});

--- a/rules/expensify.js
+++ b/rules/expensify.js
@@ -15,6 +15,7 @@ module.exports = {
         'rulesdir/no-api-side-effects-method': 'error',
         'rulesdir/display-name-property': 'error',
         'rulesdir/prefer-localization': 'error',
+        'rulesdir/onyx-props-must-have-default': 'error',
         'no-restricted-imports': ['error', {
             paths: [{
                 name: 'react-native',

--- a/sample-props.js
+++ b/sample-props.js
@@ -1,0 +1,9 @@
+const samplePropTypes = {
+    propKey: Boolean,
+};
+
+const sampleDefaultProps = {
+    propKey: false,
+};
+
+export {samplePropTypes, sampleDefaultProps};


### PR DESCRIPTION
This PR creates the rule for checking that each prop obtained from `withOnyx` has been declared in prop types and assigned a value in default props.

[Slack Conversation](https://expensify.slack.com/archives/C01GTK53T8Q/p1673641691365339) on the issue.
[Github issue](https://github.com/Expensify/App/issues/14309) in E/App

## Impact
As of this [commit](https://github.com/Expensify/App/tree/e43bab50d8b61efec1d7410f4019806abbd1cdcd), there are a total of 97 components that make use of the withOnyx HOC. Out of these, there are 47 offending components that either:

- Do not have the default props declared.
- Do not have the prop types declared.
- Have an argument in withOnyx, but is not declared in propTypes.
- Have an argument in withOnyx, declared in propTypes but is a necessary prop with .isRequired.
- Have an argument in withOnyx, but is not declared in defaultProps.
- The propTypes/defaultProps are directly assigned as object instead of as a variable. The only occurrence of this issue is in [withCurrentUserPersonalDetails](https://github.com/Expensify/App/blob/e43bab50d8b61efec1d7410f4019806abbd1cdcd/src/components/withCurrentUserPersonalDetails.js#L31-L44). The requirement for this syntax is due to the workflow of the rule.

Out of these 47 components,

- 14 do not have the default props declared.
- 28 have a prop that is passed as an argument to withOnyx and is required in propType.
- 2 do not have the propTypes declared.
- 19 have one/multiple props passed as an argument to withOnyx but are not declared in propType, even when including externally imported propTypes.
- 1 has propTypes declared as an object instead of referencing to a variable.

## Workflow
1. The rule will trigger whenever `withOnyx` HOC is used in a component.
2. Checks and reports if `withOnyx` is passed at least one argument.
3. Gets the top level `Program` node of the AST.
4. Checks if the component is an HOC that wraps around another component.
5. Get the variable name of the variable containing the props from `Component.propTypes = propTypesVariable`.
6. Checks and reports if the assignment to propTypes is done by referencing to a variable instead of directly assigning an object.
7. Gets the list of variables in scope and get the variable declaration of propTypes.
8. If no existing propTypes, reports it.
9. Gets the list of properties in the propTypes. .
10. If propTypes variable is not declared in the same component but is directly imported and assigned from an external declaration, get the properties from external file and assign them to an object here.
11. Check if there is any property with the spread operator (`...`).
12. If there are any properties with the spread operator, for each one of them, if they are imported from an external file, get the properties from external file and append them to the existing properties. If they are declared in the same file, append the properties to the same object.
13. Repeat from Step 5 for defaultProps.
14. Once we have obtained all the propTypes/defaultProps, including the ones using spread operator, upto a depth of 1, we list all the properties in a single object, `propTypesProperties`/`defaultPropsProperties`.
15. For each argument passed to `withOnyx`, check if it exists in `propTypesProperties`/`defaultPropsProperties`.
16. Report accordingly.

## Testing Suite
To create the test suite for this rule, I have compiled a list of examples and their occurrences from which the test suite has been compiled. The same can be found in [this file](https://github.com/Prince-Mendiratta/eslint-config-expensify/blob/test/withOnyxComponents.md), linked externally to avoid clutter.

## Testing Rule
- Navigate to cloned Expensify/App repository.
- Run npm install git+https://github.com/Prince-Mendiratta/eslint-config-expensify.git#main
- Run npm run lint
- All the errors and warnings will be reported. Open any of them to verify the rule shows correct results.
- Try to fix the warning as shown by the rule. Ensure that the fix is reflected by the rule.

I have personally checked every single warning reported and ensured there aren't any false positives.

Signed-off-by: Prince Mendiratta <prince.mendi@gmail.com>