### PR TITLE
Remove destructuring rule

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -20,7 +20,6 @@ module.exports = {
         'react/forbid-prop-types': 'error',
         'react/no-string-refs': 'error',
         'react/jsx-filename-extension': [1, {extensions: ['.js']}],
-        'react/destructuring-assignment': ['error', 'never'],
 
         // New versions of react are removing some methods, and those methods have been prefixed with "UNSAFE_" for now.
         // We need to prevent more usages of these methods and their aliases from being added


### PR DESCRIPTION
As discussed [here](https://expensify.slack.com/archives/C01GTK53T8Q/p1680718704040129), we are going to start allowing props destructuring as part of the hooks migration. However, we don't want to require destructuring yet since that will start causing errors on tons of components. So for now, let's just remove the rule around props destructuring. Then, once the migration is complete, we can enable the rule to require it. 

Follow up issue to re-enable the rule as "always": https://github.com/Expensify/App/issues/16979