### PR TITLE
Revert "Remove destructuring rule"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-expensify",
-  "version": "2.0.32",
+  "version": "2.0.33",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-expensify",
-  "version": "2.0.32",
+  "version": "2.0.33",
   "description": "Expensify's ESLint configuration following our style guide",
   "main": "index.js",
   "repository": {

--- a/rules/react.js
+++ b/rules/react.js
@@ -20,6 +20,7 @@ module.exports = {
         'react/forbid-prop-types': 'error',
         'react/no-string-refs': 'error',
         'react/jsx-filename-extension': [1, {extensions: ['.js']}],
+        'react/destructuring-assignment': ['error', 'never'],
 
         // New versions of react are removing some methods, and those methods have been prefixed with "UNSAFE_" for now.
         // We need to prevent more usages of these methods and their aliases from being added


### PR DESCRIPTION
Reverts Expensify/eslint-config-expensify#61

After further [discussion](https://expensify.slack.com/archives/C01GTK53T8Q/p1680718704040129), we decided not to make this change. I also bumped the version so that we can update the version in npm. 