### PR TITLE
Make react props destructuring optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-expensify",
-  "version": "2.0.33",
+  "version": "2.0.34",
   "description": "Expensify's ESLint configuration following our style guide",
   "main": "index.js",
   "repository": {

--- a/rules/react.js
+++ b/rules/react.js
@@ -20,7 +20,6 @@ module.exports = {
         'react/forbid-prop-types': 'error',
         'react/no-string-refs': 'error',
         'react/jsx-filename-extension': [1, {extensions: ['.js']}],
-        'react/destructuring-assignment': ['error', 'never'],
 
         // New versions of react are removing some methods, and those methods have been prefixed with "UNSAFE_" for now.
         // We need to prevent more usages of these methods and their aliases from being added


### PR DESCRIPTION
Coming out of the end of [a long Slack discussion](https://expensify.slack.com/archives/C01GTK53T8Q/p1680718704040129) we are once more removing this rule, making props destructuring in React possible, but not required.

Technically it's a revert of [a revert](https://github.com/Expensify/eslint-config-expensify/pull/63) of [a removal of the rule](https://github.com/Expensify/eslint-config-expensify/pull/61)

This is going to be more useful as we move into functional components and hooks