### PR TITLE
Turn off destructuring error completely

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -20,6 +20,7 @@ module.exports = {
         'react/forbid-prop-types': 'error',
         'react/no-string-refs': 'error',
         'react/jsx-filename-extension': [1, {extensions: ['.js']}],
+        'react/destructuring-assignment': 'off',
 
         // New versions of react are removing some methods, and those methods have been prefixed with "UNSAFE_" for now.
         // We need to prevent more usages of these methods and their aliases from being added


### PR DESCRIPTION
Okay so removing the rule defaulted to the source config (airbnb) which had the rule on `always`. This should actually turn the rule off for real.