### PR TITLE
Update no-negated-variables rule to allow the word "notify"

### DIFF
--- a/eslint-plugin-expensify/no-negated-variables.js
+++ b/eslint-plugin-expensify/no-negated-variables.js
@@ -13,6 +13,7 @@ const BANNED_SUBSTRINGS = [
 
 const NOTABLE_EXCEPTIONS = [
     'notification',
+    'notify',
     'notch',
     'note',
     'notable',


### PR DESCRIPTION
@tgolen 
@marcaaron 

Needed in this [PR](https://github.com/Expensify/react-native-onyx/pull/238) because there is a new function introduced called `notify()`