### PR TITLE
Add lint rule for react/function-component-defintion

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -21,6 +21,13 @@ module.exports = {
         'react/no-string-refs': 'error',
         'react/jsx-filename-extension': [1, {extensions: ['.js']}],
         'react/destructuring-assignment': 'off',
+        'react/function-component-definition': [
+            'error',
+            {
+                namedComponents: 'function-declaration',
+                unnamedComponents: 'arrow-function',
+            },
+        ],
 
         // New versions of react are removing some methods, and those methods have been prefixed with "UNSAFE_" for now.
         // We need to prevent more usages of these methods and their aliases from being added


### PR DESCRIPTION
Coming from https://expensify.slack.com/archives/C02NK2DQWUX/p1686574009182619 and our [React style guide](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#should-i-declare-my-components-with-arrow-functions-const-or-the-function-keyword).

Fixes https://github.com/Expensify/App/issues/20643

Also, I tested in E/App and this rule works with the `--fix` flag so should be auto-fixable.