### PR TITLE
Remove build script from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,9 +84,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
-      - name: Build package
-        run: npm run build
-
       - name: Publish to npm
         run: npm publish
         env:


### PR DESCRIPTION
The publish.yml workflow is failing because the build script doesn't exist. AFAICT we don't need to bundle this lib so we can remove the build process entirely.

![Screenshot 2023-10-05 at 10 00 22 AM](https://github.com/Expensify/eslint-config-expensify/assets/22219519/a2282daa-2ce6-4ef5-abb3-6f70d92ae8fb)
