### PR TITLE
Avoid anonymous functions to be used in arguments/callbacks

### DIFF
--- a/eslint-plugin-expensify/CONST.js
+++ b/eslint-plugin-expensify/CONST.js
@@ -27,5 +27,6 @@ module.exports = {
         ONYX_ONE_PARAM: 'The withOnyx HOC must be passed at least one argument.',
         MUST_USE_VARIABLE_FOR_ASSIGNMENT: '{{key}} must be assigned as a variable instead of direct assignment.',
         NO_DEFAULT_PROPS: 'defaultProps should not be used in function components. Use default Arguments instead.',
+        AVOID_ANONYMOUS_FUNCTIONS: 'Prefer named functions.',
     },
 };

--- a/eslint-plugin-expensify/avoid-anonymous-functions.js
+++ b/eslint-plugin-expensify/avoid-anonymous-functions.js
@@ -1,0 +1,32 @@
+const message = require('./CONST').MESSAGE.AVOID_ANONYMOUS_FUNCTIONS;
+
+module.exports = {
+    create(context) {
+        return {
+            "CallExpression > FunctionExpression": function (node) {
+                if (!node.id && !node.generator && !node.async) {
+                    context.report({
+                        node,
+                        message,
+                    });
+                }
+            },
+            "CallExpression": function (node) {
+                if (node.arguments && node.arguments.some(arg => arg.type === "ArrowFunctionExpression" && !arg.id)) {
+                    context.report({
+                        node,
+                        message,
+                    });
+                }
+            },
+            "ReturnStatement > FunctionExpression, ReturnStatement > ArrowFunctionExpression": function (node) {
+                if (!node.id) {
+                    context.report({
+                        node,
+                        message,
+                    });
+                }
+            }
+        };
+    },
+};

--- a/eslint-plugin-expensify/tests/avoid-anonymous-functions.test.js
+++ b/eslint-plugin-expensify/tests/avoid-anonymous-functions.test.js
@@ -1,0 +1,226 @@
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../avoid-anonymous-functions');
+const message = require('../CONST').MESSAGE.AVOID_ANONYMOUS_FUNCTIONS;
+
+const ruleTester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module',
+    },
+});
+
+ruleTester.run('avoid-anonymous-functions', rule, {
+    valid: [
+        {
+            code: `
+                function test() {
+                    function innerFunction(node) {
+                        return node.isParent;
+                    }
+                    
+                    const onlyParents = nodes.filter(innerFunction);
+
+                    return onlyParents;
+                }`,
+        },
+        {
+            code: `
+                function test() {
+                    const onlyParents = nodes.filter(function innerFunction(node) {
+                        return node.isParent;
+                    });
+
+                    return onlyParents;
+                }`,
+        },
+        {
+            code: `
+                function test() {
+                    const node = {execute: function named() {}};
+                    useEffect(function innerFunction() {
+                        node.execute();
+                    }, []);
+                    return true;
+                }`,
+        },
+        {
+            code: `
+                function test() {
+                    const node = {execute: () => {}};
+                    useEffect(function* () {
+                        node.execute();
+                    }, []);
+                    return true;
+                }`,
+        },
+        {
+            code: `
+                function test() {
+                    const node = {execute: function named() {}};
+                    useEffect(node.execute, []);
+                    return true;
+                }
+            `
+        },
+        {
+            code: `
+                function test() {
+                    const node = {execute: () => {}};
+                    useEffect(node.execute, []);
+                    return true;
+                }
+            `
+        },
+        {
+            code: `
+                function test() {
+                    const node = () => {};
+                    useEffect(node, []);
+                    return true;
+                }
+            `
+        },
+        {
+            code: `
+                function test() {
+                    const filteringById = () => {};
+                    parents.filter(filteringById);
+                    return true;
+                }
+            `
+        },
+        {
+            code: `
+                function test() {
+                    function withName() {
+                        return function innerName() {};
+                    }
+                    withName();
+                    return true;
+                }
+            `
+        },
+    ],
+    invalid: [
+        {
+            code: `
+                function test() {
+                    const onlyParents = nodes.filter((node) => node.isParent);
+
+                    return onlyParents;
+                }
+            `,
+            errors: [{
+                message,
+            }],
+        },
+        {
+            code: `
+                function test() {
+                    const onlyParents = nodes.filter((node) => { 
+                        return node.isParent;
+                    });
+
+                    return onlyParents;
+                }
+            `,
+            errors: [{
+                message,
+            }],
+        },
+        {
+            code: `
+            function test() {
+                const node = {execute: function named() {}};
+                useEffect(function () {
+                    node.execute();
+                }, []);
+                return true;
+            }
+            `,
+            errors: [{
+                message,
+            }],
+        },
+        {
+            code: `
+            function test() {
+                const node = {execute: function named() {}};
+                useEffect(() => node.execute(), []);
+                return true;
+            }
+            `,
+            errors: [{
+                message,
+            }],
+        },
+        {
+            code: `
+            function test() {
+                const node = {execute: () => {}};
+                useEffect(function () {node.execute();} , []);
+                return true;
+            }
+            `,
+            errors: [{
+                message,
+            }],
+        },
+        {
+            code: `
+            function test() {
+                function rightNamed() {
+                    return () => {};
+                }
+                rightNamed();
+                return true;
+            }
+            `,
+            errors: [{
+                message,
+            }],
+        },
+        {
+            code: `
+            function test() {
+                function rightNamed() {
+                    return function () {};
+                }
+                rightNamed();
+                return true;
+            }
+            `,
+            errors: [{
+                message,
+            }],
+        },
+        {
+            code: `
+            function test() {
+                const rightNamed = () => {
+                    return function () {};
+                }
+                rightNamed();
+                return true;
+            }
+            `,
+            errors: [{
+                message,
+            }],
+        },
+        {
+            code: `
+            function test() {
+                const rightNamed = () => {
+                    return () => {};
+                }
+                rightNamed();
+                return true;
+            }
+            `,
+            errors: [{
+                message,
+            }],
+        },
+    ],
+});

--- a/rules/expensify.js
+++ b/rules/expensify.js
@@ -16,6 +16,7 @@ module.exports = {
         'rulesdir/no-api-side-effects-method': 'error',
         'rulesdir/prefer-localization': 'error',
         'rulesdir/onyx-props-must-have-default': 'error',
+        'rulesdir/avoid-anonymous-functions': 'error',
         'no-restricted-imports': ['error', {
             paths: [{
                 name: 'react-native',


### PR DESCRIPTION
Coming from: https://github.com/Expensify/eslint-config-expensify/pull/87

Avoid anonymous callback/arguments functions

Idea: https://github.com/Expensify/App/issues/38394

Basic explantation related to allowed arrow functions:

✅ Arrow functions assignments

```jsx
const workingNamed = () => {};
```

✅ Arrow functions in objects

```jsx
const person = {getName: () => {}};
```
✅ Named functions callback

```jsx
function mappingPeople(person) {};
people.map(mappingPeople);
people.filter(function filterPerson() {});
useEffect(function handlingConnection() {}, []);
```

❌ callback arrow functions

```jsx
people.map(() => {});
people.filter(() => {});
useEffect(() => {}, []);
useEffect(function() {}, []);
```
---
1: adding a name to an anonymous function used by `useMemo`
```
const options = useMemo(
        function orderingReports() {
           // code
           return value;
        }, []);
```
2: creating an arrow function and storing it into a variable
```
const filteringForSideBar = (report) => { // code };
someValues.filter(filteringForSideBar);
```
3: using a function from an Object
```
const forEachObj = {
        callback: (report) => { //code }
}
```
<img width="1360" alt="named_functions" src="https://github.com/Expensify/eslint-config-expensify/assets/1676818/becb3b37-1af0-405b-9cbf-a3ceca32cb1b">

Without all the above ways we only see `(anonymous)`, and many of the functions wouldn't show up.

<img width="1161" alt="named_functions_anonymous" src="https://github.com/Expensify/eslint-config-expensify/assets/1676818/45badf3a-47eb-4a3f-bb20-cffa78c5068a">


---
1: passing a function to an `useEffect`
```
useEffect(() => {
        console.log('1BEING ANONYMOUS');
        fibonacci(20);
    }, []);
```
2: passing a named function
```
useEffect(function solvingFibEleven() {
        console.log('2NotBEING ANONYMOUS');
        fibonacci(20);
    }, []);
```    
<img width="1113" alt="named_functions_useEffect" src="https://github.com/Expensify/eslint-config-expensify/assets/1676818/7682d864-5000-49d3-b2d3-c4f32b4beb6d">

---
You can also search for those functions, making it easier to navigate through the performance graph

<img width="1386" alt="named_functions_search" src="https://github.com/Expensify/eslint-config-expensify/assets/1676818/7027f944-be6a-4112-adae-2c610b0e892b">
