### PR TITLE
[No QA] Add rule metadata for use-periods-for-error-messages

### DIFF
--- a/eslint-plugin-expensify/use-periods-for-error-messages.js
+++ b/eslint-plugin-expensify/use-periods-for-error-messages.js
@@ -1,7 +1,13 @@
-require('lodash/get');
 const message = require('./CONST').MESSAGE.USE_PERIODS_ERROR_MESSAGES;
 
 module.exports = {
+    meta: {
+        type: 'suggestion',
+        docs: {
+            description: 'Enforce using periods at the end of error messages',
+        },
+        fixable: 'code',
+    },
     create(context) {
         return {
             Property(node) {


### PR DESCRIPTION
This rule is not currently compatible with ESLint 8+ (which we currently list as a dependency for this package):

```
Error: Fixable rules must set the `meta.fixable` property to "code" or "whitespace".
```