### PR TITLE
Add testing steps to the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ This package provides Expensify's .eslintrc as an extensible shared config. Most
 1. Make a change
 2. Bump the version in package.json and submit your PR
 
+### Testing
+
+After  you have submitted a PR with a new version in the `package.json` file
+
+1. Get the full commitID of the last commit in your PR and run `npm install git+https://github.com/Expensify/eslint-config-expensify.git#COMMIT_ID` in the repo against which you want to test those changes.
+2. This should update the version of `eslint-config-expensify` in `package-lock.json` file, and ensures the repo is referencing to the correct version of the eslint config.
+3. Now, you can run `npm run lint` or perform any other tests you want in that repo.
+
 ### After PR is merged
 You need to publish the newest version of this to NPM so that we can update it in the other repos
 1. From the command line, in the directory for this repo:

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ This package provides Expensify's .eslintrc as an extensible shared config. Most
 
 ### Testing
 
-After  you have submitted a PR with a new version in the `package.json` file
+After you have submitted a PR with an updated version in the `package.json` file,
 
-1. Get the full commitID of the last commit in your PR and run `npm install git+https://github.com/Expensify/eslint-config-expensify.git#COMMIT_ID` in the repo against which you want to test those changes.
+1. Get the full commitID of the last commit in your PR, and run `npm install git+https://github.com/Expensify/eslint-config-expensify.git#COMMIT_ID` in the repo against which you want to test those changes.
 2. This should update the version of `eslint-config-expensify` in `package-lock.json` file, and ensures the repo is referencing to the correct version of the eslint config.
 3. Now, you can run `npm run lint` or perform any other tests you want in that repo.
 


### PR DESCRIPTION
Testing steps were not present in the README. We tested the PR using these steps in this PR https://github.com/Expensify/eslint-config-expensify/pull/105#issuecomment-2231466900
So, noting them down