### PR TITLE
Handle functions and assignment in prefer-at condition

### DIFF
--- a/eslint-plugin-expensify/prefer-at.js
+++ b/eslint-plugin-expensify/prefer-at.js
@@ -105,7 +105,7 @@ module.exports = {
         function shouldIgnoreNode(node) {
             return (
                 node.parent &&
-                (node.parent.type === AST_NODE_TYPES.MemberExpression || node.parent.type === AST_NODE_TYPES.OptionalMemberExpression) &&
+                (node.parent.type === AST_NODE_TYPES.MemberExpression) &&
                 node.parent.property === node
             );
         }

--- a/eslint-plugin-expensify/prefer-at.js
+++ b/eslint-plugin-expensify/prefer-at.js
@@ -1,6 +1,8 @@
 const { AST_NODE_TYPES, ESLintUtils } = require('@typescript-eslint/utils');
 const message = require('./CONST').MESSAGE.PREFER_AT;
 
+const { isLeftHandSide } = require('./utils/is-left-hand-side');
+
 module.exports = {
     meta: {
         fixable: 'code',
@@ -67,23 +69,19 @@ module.exports = {
             return indexExpression;
         }
 
-        function isAssignmentExpression(node) {
-            return node.parent && node.parent.type === AST_NODE_TYPES.AssignmentExpression && node.parent.left === node;
-        }
-
         function checkNode(node) {
             if (node.type === AST_NODE_TYPES.MemberExpression && node.property) {
                 if (!isArrayType(node.object)) {
                     return;
                 }
 
-                // Skip if the property is a method (like a.map)
+                // Skip if the property is a method (like a?.map)
                 if (node.parent && node.parent.type === AST_NODE_TYPES.CallExpression && node.parent.callee === node) {
                     return;
                 }
 
-                // Skip if the node is part of an assignment expression (like a[i] = 2)
-                if (isAssignmentExpression(node)) {
+                // Skip if the node is part of an assignment expression
+                if (isLeftHandSide(node)) {
                     return;
                 }
 

--- a/eslint-plugin-expensify/prefer-at.js
+++ b/eslint-plugin-expensify/prefer-at.js
@@ -105,7 +105,7 @@ module.exports = {
         function shouldIgnoreNode(node) {
             return (
                 node.parent &&
-                (node.parent.type === AST_NODE_TYPES.MemberExpression) &&
+                node.parent.type === AST_NODE_TYPES.MemberExpression &&
                 node.parent.property === node
             );
         }

--- a/eslint-plugin-expensify/prefer-at.js
+++ b/eslint-plugin-expensify/prefer-at.js
@@ -77,12 +77,12 @@ module.exports = {
                     return;
                 }
 
-                // Skip if the property is a method (like a?.map)
+                // Skip if the property is a method (like a.map)
                 if (node.parent && node.parent.type === AST_NODE_TYPES.CallExpression && node.parent.callee === node) {
                     return;
                 }
 
-                // Skip if the node is part of an assignment expression
+                // Skip if the node is part of an assignment expression (like a[i] = 2)
                 if (isAssignmentExpression(node)) {
                     return;
                 }

--- a/eslint-plugin-expensify/prefer-at.js
+++ b/eslint-plugin-expensify/prefer-at.js
@@ -67,9 +67,23 @@ module.exports = {
             return indexExpression;
         }
 
+        function isAssignmentExpression(node) {
+            return node.parent && node.parent.type === AST_NODE_TYPES.AssignmentExpression && node.parent.left === node;
+        }
+
         function checkNode(node) {
             if (node.type === AST_NODE_TYPES.MemberExpression && node.property) {
                 if (!isArrayType(node.object)) {
+                    return;
+                }
+
+                // Skip if the property is a method (like a?.map)
+                if (node.parent && node.parent.type === AST_NODE_TYPES.CallExpression && node.parent.callee === node) {
+                    return;
+                }
+
+                // Skip if the node is part of an assignment expression
+                if (isAssignmentExpression(node)) {
                     return;
                 }
 
@@ -91,7 +105,7 @@ module.exports = {
         function shouldIgnoreNode(node) {
             return (
                 node.parent &&
-                node.parent.type === AST_NODE_TYPES.MemberExpression &&
+                (node.parent.type === AST_NODE_TYPES.MemberExpression || node.parent.type === AST_NODE_TYPES.OptionalMemberExpression) &&
                 node.parent.property === node
             );
         }

--- a/eslint-plugin-expensify/tests/prefer-at.test.js
+++ b/eslint-plugin-expensify/tests/prefer-at.test.js
@@ -66,6 +66,12 @@ ruleTester.run('prefer-at', rule, {
         {
             code: 'const a = ["a", "b", "c"] as const; a[0]',
         },
+        {
+            code: 'const example = [1, 2, 3, 4]; example.map(x => x * 2);',
+        },
+        {
+            code: 'const example = [1, 2, 3, 4]; const x = 1; example[x] = 5;',
+        },
     ],
     invalid: [
         {

--- a/eslint-plugin-expensify/utils/is-left-hand-side.js
+++ b/eslint-plugin-expensify/utils/is-left-hand-side.js
@@ -1,22 +1,26 @@
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/utils/is-left-hand-side.js
 
+const { AST_NODE_TYPES } = require('@typescript-eslint/utils');
+
 function isLeftHandSide(node) {
+	const { parent } = node;
+
 	return (
-		(node.parent.type === 'AssignmentExpression' || node.parent.type === 'AssignmentPattern')
-		&& node.parent.left === node
+		(parent.type === AST_NODE_TYPES.AssignmentExpression || parent.type === AST_NODE_TYPES.AssignmentPattern)
+		&& parent.left === node
 	)
-	|| (node.parent.type === 'UpdateExpression' && node.parent.argument === node)
-	|| (node.parent.type === 'ArrayPattern' && node.parent.elements.includes(node))
+	|| (parent.type === AST_NODE_TYPES.UpdateExpression && parent.argument === node)
+	|| (parent.type === AST_NODE_TYPES.ArrayPattern && parent.elements.includes(node))
 	|| (
-		node.parent.type === 'Property'
-		&& node.parent.value === node
-		&& node.parent.parent.type === 'ObjectPattern'
-		&& node.parent.parent.properties.includes(node.parent)
+		parent.type === AST_NODE_TYPES.Property
+		&& parent.value === node
+		&& parent.parent.type === AST_NODE_TYPES.ObjectPattern
+		&& parent.parent.properties.includes(parent)
 	)
 	|| (
-		node.parent.type === 'UnaryExpression'
-		&& node.parent.operator === 'delete'
-		&& node.parent.argument === node
+		parent.type === AST_NODE_TYPES.UnaryExpression
+		&& parent.operator === 'delete'
+		&& parent.argument === node
 	);
 }
 

--- a/eslint-plugin-expensify/utils/is-left-hand-side.js
+++ b/eslint-plugin-expensify/utils/is-left-hand-side.js
@@ -1,0 +1,23 @@
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/utils/is-left-hand-side.js
+
+function isLeftHandSide(node) {
+	return (
+		(node.parent.type === 'AssignmentExpression' || node.parent.type === 'AssignmentPattern')
+		&& node.parent.left === node
+	)
+	|| (node.parent.type === 'UpdateExpression' && node.parent.argument === node)
+	|| (node.parent.type === 'ArrayPattern' && node.parent.elements.includes(node))
+	|| (
+		node.parent.type === 'Property'
+		&& node.parent.value === node
+		&& node.parent.parent.type === 'ObjectPattern'
+		&& node.parent.parent.properties.includes(node.parent)
+	)
+	|| (
+		node.parent.type === 'UnaryExpression'
+		&& node.parent.operator === 'delete'
+		&& node.parent.argument === node
+	);
+}
+
+module.exports = { isLeftHandSide };


### PR DESCRIPTION
https://github.com/Expensify/App/issues/43055

This is a follow-up to include handling of functions like map and assignment like `a[i] = 2`.