### PR TITLE
Create prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth Rule

### DIFF
--- a/eslint-plugin-expensify/CONST.js
+++ b/eslint-plugin-expensify/CONST.js
@@ -33,6 +33,6 @@ module.exports = {
         PREFER_TYPE_FEST_TUPLE_TO_UNION: 'Prefer using `TupleToUnion` from `type-fest` for converting tuple types to union types.',
         PREFER_TYPE_FEST_VALUE_OF: 'Prefer using `ValueOf` from `type-fest` to extract the type of the properties of an object.',
         PREFER_AT: 'Prefer using the `.at()` method for array element access.',
-        PREFER_SHOULD_USE_NARROW_LAYOUT_INSTEAD_OF_IS_SMALL_SCREEN_WIDTH: 'Avoid using isSmallScreenWidth from useResponsiveLayout; use shouldUseNarrowLayout instead whenever possible.',  
+        PREFER_SHOULD_USE_NARROW_LAYOUT_INSTEAD_OF_IS_SMALL_SCREEN_WIDTH: 'Prefer using `shouldUseNarrowLayout` instead of `isSmallScreenWidth` from `useResponsiveLayout`.',  
     },
 };

--- a/eslint-plugin-expensify/CONST.js
+++ b/eslint-plugin-expensify/CONST.js
@@ -33,5 +33,6 @@ module.exports = {
         PREFER_TYPE_FEST_TUPLE_TO_UNION: 'Prefer using `TupleToUnion` from `type-fest` for converting tuple types to union types.',
         PREFER_TYPE_FEST_VALUE_OF: 'Prefer using `ValueOf` from `type-fest` to extract the type of the properties of an object.',
         PREFER_AT: 'Prefer using the `.at()` method for array element access.',
+        PREFER_SHOULD_USE_NARROW_LAYOUT_INSTEAD_OF_IS_SMALL_SCREEN_WIDTH: 'Avoid using isSmallScreenWidth from useResponsiveLayout; use shouldUseNarrowLayout instead whenever possible.',  
     },
 };

--- a/eslint-plugin-expensify/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth.js
+++ b/eslint-plugin-expensify/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth.js
@@ -1,0 +1,98 @@
+const _ = require("underscore");
+const CONST = require("./CONST");
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Warn against using isSmallScreenWidth from useResponsiveLayout and suggest using shouldUseNarrowLayout instead.",
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      VariableDeclarator(node) {
+        if (
+          !node.init ||
+          !node.init.callee ||
+          node.init.callee.name !== "useResponsiveLayout"
+        ) {
+          return;
+        }
+
+        // Check for 'const {isSmallScreenWidth, ...} = useResponsiveLayout();' pattern
+        if (node.id.type === "ObjectPattern") {
+          node.id.properties.forEach((property) => {
+            if (!property.key || property.key.name !== "isSmallScreenWidth") {
+              return;
+            }
+            context.report({
+              node: property,
+              message:
+                CONST.MESSAGE
+                  .PREFER_SHOULD_USE_NARROW_LAYOUT_INSTEAD_OF_IS_SMALL_SCREEN_WIDTH,
+            });
+          });
+        }
+
+        // Check for 'const var = useResponsiveLayout();' and use of this var
+        const variableName = node.id.name;
+        const variableUsages = _.filter(
+          context.getScope().references,
+          (reference) => reference.identifier.name === variableName
+        );
+        variableUsages.forEach((usage) => {
+          const parent = usage.identifier.parent;
+
+          // Check for 'const isSmallScreen = var.isSmallScreenWidth;' pattern
+          if (
+            parent.type === "MemberExpression" &&
+            parent.property.name === "isSmallScreenWidth"
+          ) {
+            context.report({
+              node: parent.property,
+              message:
+                CONST.MESSAGE
+                  .PREFER_SHOULD_USE_NARROW_LAYOUT_INSTEAD_OF_IS_SMALL_SCREEN_WIDTH,
+            });
+          }
+
+          // Check for 'const {isSmallScreenWidth} = var;' pattern
+          if (
+            parent.type === "VariableDeclarator" &&
+            parent.id.type === "ObjectPattern"
+          ) {
+            parent.id.properties.forEach((property) => {
+              if (!property.key || property.key.name !== "isSmallScreenWidth") {
+                return;
+              }
+              context.report({
+                node: property,
+                message:
+                  CONST.MESSAGE
+                    .PREFER_SHOULD_USE_NARROW_LAYOUT_INSTEAD_OF_IS_SMALL_SCREEN_WIDTH,
+              });
+            });
+          }
+        });
+      },
+      MemberExpression(node) {
+        // Check for 'const isSmallScreenWidth = useResponsiveLayout().isSmallScreenWidth;' pattern
+        if (
+          node.object.type !== "CallExpression" ||
+          node.object.callee.name !== "useResponsiveLayout" ||
+          node.property.name !== "isSmallScreenWidth"
+        ) {
+          return;
+        }
+        context.report({
+          node,
+          message:
+            CONST.MESSAGE
+              .PREFER_SHOULD_USE_NARROW_LAYOUT_INSTEAD_OF_IS_SMALL_SCREEN_WIDTH,
+        });
+      },
+    };
+  },
+};

--- a/eslint-plugin-expensify/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth.js
+++ b/eslint-plugin-expensify/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth.js
@@ -12,6 +12,9 @@ module.exports = {
     schema: [],
   },
   create(context) {
+
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+
     return {
       VariableDeclarator(node) {
         if (
@@ -37,10 +40,12 @@ module.exports = {
           });
         }
 
+        const scope = sourceCode.getScope ? sourceCode.getScope(node) : context.getScope();
+
         // Check for 'const var = useResponsiveLayout();' and use of this var
         const variableName = node.id.name;
         const variableUsages = _.filter(
-          context.getScope().references,
+          scope.references,
           (reference) => reference.identifier.name === variableName
         );
         variableUsages.forEach((usage) => {

--- a/eslint-plugin-expensify/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth.js
+++ b/eslint-plugin-expensify/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth.js
@@ -1,3 +1,4 @@
+const {AST_NODE_TYPES} = require("@typescript-eslint/utils");
 const _ = require("underscore");
 const CONST = require("./CONST");
 
@@ -22,7 +23,7 @@ module.exports = {
         }
 
         // Check for 'const {isSmallScreenWidth, ...} = useResponsiveLayout();' pattern
-        if (node.id.type === "ObjectPattern") {
+        if (node.id.type === AST_NODE_TYPES.ObjectPattern) {
           node.id.properties.forEach((property) => {
             if (!property.key || property.key.name !== "isSmallScreenWidth") {
               return;
@@ -45,9 +46,9 @@ module.exports = {
         variableUsages.forEach((usage) => {
           const parent = usage.identifier.parent;
 
-          // Check for 'const isSmallScreen = var.isSmallScreenWidth;' pattern
+          // Check for 'const isSmallScreenWidth = var.isSmallScreenWidth;' pattern
           if (
-            parent.type === "MemberExpression" &&
+            parent.type === AST_NODE_TYPES.MemberExpression &&
             parent.property.name === "isSmallScreenWidth"
           ) {
             context.report({
@@ -60,8 +61,8 @@ module.exports = {
 
           // Check for 'const {isSmallScreenWidth} = var;' pattern
           if (
-            parent.type === "VariableDeclarator" &&
-            parent.id.type === "ObjectPattern"
+            parent.type === AST_NODE_TYPES.VariableDeclarator &&
+            parent.id.type === AST_NODE_TYPES.ObjectPattern
           ) {
             parent.id.properties.forEach((property) => {
               if (!property.key || property.key.name !== "isSmallScreenWidth") {

--- a/eslint-plugin-expensify/tests/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth.test.js
+++ b/eslint-plugin-expensify/tests/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth.test.js
@@ -1,0 +1,74 @@
+const RuleTester = require("eslint").RuleTester;
+const rule = require("../prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth");
+const message =
+  require("../CONST").MESSAGE
+    .PREFER_SHOULD_USE_NARROW_LAYOUT_INSTEAD_OF_IS_SMALL_SCREEN_WIDTH;
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: "module",
+  },
+});
+
+ruleTester.run(
+  "prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth",
+  rule,
+  {
+    valid: [
+      {
+        code: "const {shouldUseNarrowLayout} = useResponsiveLayout();",
+      },
+    ],
+    invalid: [
+      {
+        code: "const {isSmallScreenWidth} = useResponsiveLayout();",
+        errors: [
+          {
+            message,
+          },
+        ],
+      },
+      {
+        code: "const {isSmallScreenWidth, shouldUseNarrowLayout} = useResponsiveLayout();",
+        errors: [
+          {
+            message,
+          },
+        ],
+      },
+      {
+        code: `
+            const isSmallScreenWidth = useResponsiveLayout().isSmallScreenWidth;
+            `,
+        errors: [
+          {
+            message,
+          },
+        ],
+      },
+      {
+        code: `
+            const dimensions = useResponsiveLayout();
+            const isSmallScreenWidth = dimensions.isSmallScreenWidth;
+            `,
+        errors: [
+          {
+            message,
+          },
+        ],
+      },
+      {
+        code: `
+            const dimensions = useResponsiveLayout();
+            const {isSmallScreenWidth} = dimensions;
+            `,
+        errors: [
+          {
+            message,
+          },
+        ],
+      },
+    ],
+  }
+);

--- a/rules/expensify.js
+++ b/rules/expensify.js
@@ -28,6 +28,7 @@ module.exports = {
                 message: 'Please use SafeAreaView from react-native-safe-area-context',
             }],
         }],
+        "rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth": "error",
     },
 };
 

--- a/rules/expensify.js
+++ b/rules/expensify.js
@@ -28,7 +28,7 @@ module.exports = {
                 message: 'Please use SafeAreaView from react-native-safe-area-context',
             }],
         }],
-        "rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth": "error",
+        "rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth": "warn",
     },
 };
 


### PR DESCRIPTION
https://github.com/Expensify/App/issues/30528

Test:
1. `npm install git+https://github.com/Expensify/eslint-config-expensify.git#1d72b89949db775b76e7f2a39707720d24d07d1c`
2. `npm run lint`

<img width="1004" alt="Screenshot 2024-09-15 at 4 15 41 PM" src="https://github.com/user-attachments/assets/96799291-ee13-493c-b953-304946494b6c">
