### PR TITLE
Use `number` instead of `pull_request_number` for correct output

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
   get_pull_request:
     runs-on: ubuntu-latest
     outputs:
-      pull_request_number: ${{ steps.getMergedPullRequest.outputs.pull_request_number }}
+      pull_request_number: ${{ steps.getMergedPullRequest.outputs.number }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Fixes broken publish build: https://github.com/Expensify/eslint-config-expensify/actions/runs/11279500875

This error I believe is saying "the `pull_request_number` variable is empty and needs to be a number".

We should use `number` as that's the correct output: 

https://github.com/Expensify/eslint-config-expensify/pull/123/files#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L94

https://github.com/actions-ecosystem/action-get-merged-pull-request?tab=readme-ov-file#outputs