### PR TITLE
Use `repository` instead of `action_repository`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,6 @@ jobs:
     uses: Expensify/GitHub-Actions/.github/workflows/npmPublish.yml@main
     secrets: inherit
     with:
-      repository: ${{ github.action_repository }}
+      repository: ${{ github.repository }}
       # 'outputs' provides a string, and we need a number, so we use fromJSON to convert it
       pull_request_number: ${{ fromJSON(needs.get_pull_request.outputs.pull_request_number) }}


### PR DESCRIPTION
Use the correct context variable: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs