### PR TITLE
Add CLA Assistant for @Expensify CLA

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,7 +4,7 @@ on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [opened, closed, synchronize]
+    types: [opened, synchronize]
 
 jobs:
   CLA:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,12 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+jobs:
+  CLA:
+    uses: Expensify/GitHub-Actions/.github/workflows/cla.yml@main
+    secrets: inherit


### PR DESCRIPTION
### Details
Adds a CLA to this repository, which is required for all contributors to sign before contributing to this repository.

### Related Issues
Fixes https://github.com/Expensify/Expensify/issues/438820
