### PR TITLE
Add `CONST.DEFAULT_NUMBER_ID` case to `no-default-id-values` ESLint rule

### DIFF
--- a/eslint-plugin-expensify/no-default-id-values.js
+++ b/eslint-plugin-expensify/no-default-id-values.js
@@ -71,6 +71,7 @@ module.exports = {
             "id || '0'",
             " : '-1'",
             " : '0'",
+            'CONST.DEFAULT_NUMBER_ID}`',
         ];
 
         disallowedNumberDefaults.forEach((pattern) => {

--- a/eslint-plugin-expensify/tests/no-default-id-values.test.js
+++ b/eslint-plugin-expensify/tests/no-default-id-values.test.js
@@ -256,5 +256,33 @@ ruleTester.run('no-default-id-values', rule, {
                 messageId: 'disallowedStringDefault',
             }],
         },
+        {
+            // eslint-disable-next-line no-template-curly-in-string
+            code: 'const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${transaction?.reportID ?? CONST.DEFAULT_NUMBER_ID}`);',
+            errors: [{
+                messageId: 'disallowedStringDefault',
+            }],
+        },
+        {
+            // eslint-disable-next-line no-template-curly-in-string
+            code: 'useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${report.parentReportID || CONST.DEFAULT_NUMBER_ID}`);',
+            errors: [{
+                messageId: 'disallowedStringDefault',
+            }],
+        },
+        {
+            // eslint-disable-next-line no-template-curly-in-string
+            code: 'const policyID = policy ? policy.id : `${CONST.DEFAULT_NUMBER_ID}`;',
+            errors: [{
+                messageId: 'disallowedStringDefault',
+            }],
+        },
+        {
+            // eslint-disable-next-line no-template-curly-in-string
+            code: 'const policyID = policy?.id ?? `${CONST.DEFAULT_NUMBER_ID}`;',
+            errors: [{
+                messageId: 'disallowedStringDefault',
+            }],
+        },
     ],
 });


### PR DESCRIPTION
Issue: https://github.com/Expensify/App/issues/55814

Context: https://expensify.slack.com/archives/C01GTK53T8Q/p1737913879440099