### PR TITLE
Implement provide-canBeMissing-in-useOnyx rule

### DIFF
--- a/eslint-plugin-expensify/provide-canBeMissing-in-useOnyx.js
+++ b/eslint-plugin-expensify/provide-canBeMissing-in-useOnyx.js
@@ -1,0 +1,103 @@
+const _ = require('underscore');
+
+/**
+ * @typedef {import('eslint').Rule.RuleModule} RuleModule
+ * @typedef {import('estree').ObjectExpression} ObjectExpression
+ */
+
+/** @type {RuleModule} */
+module.exports = {
+    name: 'provide-canBeMissing-in-useOnyx',
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Enforces use of "canBeMissing" option in useOnyx calls.',
+            recommended: 'error',
+        },
+        schema: [],
+        messages: {
+            provideCanBeMissing: 'Provide the "canBeMissing" option to the useOnyx() call.',
+        },
+    },
+    create(context) {
+        /**
+         * Find the variable declaration and return the value.
+         *
+         * @param {string} name - The name of the variable to resolve.
+         * @returns {ObjectExpression|null}
+         */
+        function getVariableValue(name) {
+            try {
+                const scope = context.getScope();
+                const variable = scope.set.get(name);
+
+                if (variable && variable.defs.length > 0) {
+                    const def = variable.defs[0];
+                    if (def.node.init && def.node.init.type === 'ObjectExpression') {
+                        return def.node.init;
+                    }
+                }
+            } catch (e) {
+                return null;
+            }
+
+            return null;
+        }
+
+        return {
+            VariableDeclarator(node) {
+                if (
+                    !node.init
+                    || node.init.type !== 'CallExpression'
+                    || node.init.callee.name !== 'useOnyx'
+                ) {
+                    return;
+                }
+
+                if (node.init.arguments.length < 2) {
+                    context.report({
+                        node: node.init,
+                        messageId: 'provideCanBeMissing',
+                    });
+                    return;
+                }
+
+                const optionsArgument = node.init.arguments[1];
+                switch (optionsArgument.type) {
+                    case 'ObjectExpression': {
+                        if (!_.some(optionsArgument.properties, property => property.type === 'Property' && property.key.name === 'canBeMissing')) {
+                            context.report({
+                                node: node.init,
+                                messageId: 'provideCanBeMissing',
+                            });
+                        }
+                        break;
+                    }
+
+                    case 'Identifier': {
+                        const resolvedValue = getVariableValue(optionsArgument.name);
+                        if (!resolvedValue) {
+                            context.report({
+                                node: node.init,
+                                messageId: 'provideCanBeMissing',
+                            });
+                            return;
+                        }
+
+                        if (!_.some(resolvedValue.properties, property => property.type === 'Property' && property.key.name === 'canBeMissing')) {
+                            context.report({
+                                node: node.init,
+                                messageId: 'provideCanBeMissing',
+                            });
+                        }
+                        break;
+                    }
+
+                    default: {
+                        break;
+                    }
+                }
+            },
+        };
+    },
+};

--- a/eslint-plugin-expensify/tests/provide-canBeMissing-in-useOnyx.test.js
+++ b/eslint-plugin-expensify/tests/provide-canBeMissing-in-useOnyx.test.js
@@ -1,0 +1,64 @@
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../provide-canBeMissing-in-useOnyx');
+
+const ruleTester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module',
+    },
+});
+
+ruleTester.run('provide-canBeMissing-in-useOnyx', rule, {
+    valid: [
+        {
+            code: 'const [data] = useOnyx(ONYXKEYS.DATA, {allowStaleData: true, canBeMissing: false});',
+        },
+        {
+            code: 'const [data] = useOnyx(ONYXKEYS.DATA, {canBeMissing: false}, []);',
+        },
+        {
+            code: `
+                const options = {allowStaleData: true, canBeMissing: false};
+                const [data] = useOnyx(ONYXKEYS.DATA, options);
+            `,
+        },
+    ],
+    invalid: [
+        {
+            code: 'const [data] = useOnyx(ONYXKEYS.DATA);',
+            errors: [{
+                messageId: 'provideCanBeMissing',
+            }],
+        },
+        {
+            code: 'const [data] = useOnyx(ONYXKEYS.DATA, {allowStaleData: true});',
+            errors: [{
+                messageId: 'provideCanBeMissing',
+            }],
+        },
+        {
+            code: 'const [data] = useOnyx(ONYXKEYS.DATA, undefined, []);',
+            errors: [{
+                messageId: 'provideCanBeMissing',
+            }],
+        },
+        {
+            code: `
+                const options = {allowStaleData: true};
+                const [data] = useOnyx(ONYXKEYS.DATA, options);
+            `,
+            errors: [{
+                messageId: 'provideCanBeMissing',
+            }],
+        },
+        {
+            code: `
+                const undefinedOptions = undefined;
+                const [data] = useOnyx(ONYXKEYS.DATA, undefinedOptions);
+            `,
+            errors: [{
+                messageId: 'provideCanBeMissing',
+            }],
+        },
+    ],
+});


### PR DESCRIPTION
This PR implements a new ESLint rule to enforce `useOnyx` calls to provide the `canBeMissing` option. **It's intended to be used on .eslintrc.changed.js, that will only run for the changes files of a PR.**

This rule should only be used when the [Onyx PR](https://github.com/Expensify/react-native-onyx/pull/623) is merged and its release available in E/App.

Issue: https://github.com/Expensify/App/issues/58499