### PR TITLE
Prefer-tokenized-search rule v2

### DIFF
--- a/eslint-plugin-expensify/CONST.js
+++ b/eslint-plugin-expensify/CONST.js
@@ -36,5 +36,6 @@ module.exports = {
         PREFER_SHOULD_USE_NARROW_LAYOUT_INSTEAD_OF_IS_SMALL_SCREEN_WIDTH: 'Prefer using `shouldUseNarrowLayout` instead of `isSmallScreenWidth` from `useResponsiveLayout`.',
         NO_USE_STATE_INITIALIZER_CALL_FUNCTION:
             'Avoid calling a function directly in the useState initializer. Use an initializer function instead (a callback).',
+        PREFER_TOKENIZED_SEARCH: 'Use tokenizedSearch instead of filter().includes() for better search performance and accuracy.',
     },
 };

--- a/eslint-plugin-expensify/prefer-tokenized-search.js
+++ b/eslint-plugin-expensify/prefer-tokenized-search.js
@@ -1,0 +1,141 @@
+const lodashGet = require('lodash/get');
+const lodashSome = require('lodash/some');
+const lodashIsArray = require('lodash/isArray');
+const lodashIsObject = require('lodash/isObject');
+const lodashFilter = require('lodash/filter');
+const lodashEntries = require('lodash/entries');
+const message = require('./CONST').MESSAGE.PREFER_TOKENIZED_SEARCH;
+
+/**
+ * Unwraps a ChainExpression if present.
+ * @param {Object} node
+ * @returns {Object}
+ */
+function extractCallExpression(node) {
+    return node && node.type === 'ChainExpression' ? node.expression : node;
+}
+
+/**
+ * Recursively checks if a node contains a call to toLowerCase.
+ * Skips the 'parent' property to avoid circular references.
+ * @param {Object} node
+ * @returns {Boolean}
+ */
+function containsToLowerCase(node) {
+    if (!node || typeof node !== 'object') { return false; }
+
+    if (node.type === 'CallExpression') {
+        const callExp = extractCallExpression(node);
+        if (lodashGet(callExp, 'callee.property.name') === 'toLowerCase') {
+            return true;
+        }
+    }
+
+    return lodashSome(Object.entries(node), ([key, child]) => {
+        if (key === 'parent') { return false; }
+
+        if (lodashIsArray(child)) {
+            return lodashSome(child, c => containsToLowerCase(c));
+        }
+
+        return child && typeof child === 'object' && containsToLowerCase(child);
+    });
+}
+
+/**
+ * Checks if a given call expression is suspicious:
+ *   - It calls "includes" on something that, somewhere in its chain,
+ *     calls toLowerCase.
+ * @param {Object} expr
+ * @returns {Boolean}
+ */
+function checkExpression(expr) {
+    if (!expr) {
+        return false;
+    }
+
+    // If the expression is a call expression, check if it's an includes call.
+    if (expr.type === 'CallExpression') {
+        const callExp = extractCallExpression(expr);
+        if (lodashGet(callExp, 'callee.property.name') === 'includes') {
+            const lowerCaseCall = lodashGet(callExp, 'callee.object');
+            if (containsToLowerCase(lowerCaseCall)) {
+                return true;
+            }
+        }
+    }
+
+    // If the expression is a logical expression (e.g. using ||), check both sides.
+    if (expr.type === 'LogicalExpression') {
+        return checkExpression(expr.left) || checkExpression(expr.right);
+    }
+    return false;
+}
+
+/**
+ * Recursively traverses a node's AST to find any suspicious call expression.
+ * Skips properties named 'parent' to avoid circular references.
+ * @param {Object} node
+ * @returns {Boolean}
+ */
+function findSuspiciousCall(node) {
+    if (!node || !lodashIsObject(node)) { return false; }
+
+    if (node.type === 'CallExpression' && checkExpression(node)) {
+        return true;
+    }
+
+    const entries = lodashFilter(lodashEntries(node), ([key]) => key !== 'parent');
+
+    return lodashSome(entries, ([, child]) => {
+        if (lodashIsArray(child)) {
+            return lodashSome(child, c => findSuspiciousCall(c));
+        }
+        return lodashIsObject(child) && findSuspiciousCall(child);
+    });
+}
+
+/**
+ * Determines if the given CallExpression node is a filter call
+ * that uses includes on a lowercased value.
+ * @param {Object} node
+ * @returns {Boolean}
+ */
+function isUsingFilterIncludes(node) {
+    if (lodashGet(node, 'callee.property.name') !== 'filter') {
+        return false;
+    }
+
+    const callback = lodashGet(node, 'arguments[0]');
+    if (!callback || callback.type !== 'ArrowFunctionExpression') {
+        return false;
+    }
+
+    // For expression-bodied arrow functions.
+    if (callback.body.type !== 'BlockStatement') {
+        const expr = extractCallExpression(callback.body);
+        return checkExpression(expr);
+    }
+
+    // For block-bodied arrow functions, recursively search the entire body.
+    return findSuspiciousCall(callback.body);
+}
+
+module.exports = {
+    meta: {
+        type: 'suggestion',
+        docs: {
+            description: 'Enforce the use of tokenized search instead of direct string includes',
+        },
+        schema: [],
+    },
+    create: context => ({
+        CallExpression: (node) => {
+            if (!isUsingFilterIncludes(node)) {
+                return;
+            }
+
+            context.report({node, message});
+        },
+    }),
+};

--- a/eslint-plugin-expensify/tests/prefer-tokenized-search.test.js
+++ b/eslint-plugin-expensify/tests/prefer-tokenized-search.test.js
@@ -1,0 +1,100 @@
+const {RuleTester} = require('eslint');
+const rule = require('../prefer-tokenized-search');
+const message = require('../CONST').MESSAGE.PREFER_TOKENIZED_SEARCH;
+
+const ruleTester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module',
+    },
+});
+
+ruleTester.run('prefer-tokenized-search', rule, {
+    valid: [
+        {
+            code: 'const result = tokenizedSearch(items, searchValue, (item) => [item.name ?? \'\']);',
+        },
+        {
+            code: 'const filtered = items.filter((item) => item.active);',
+        },
+        {
+            code: 'const found = array.some((val) => val === searchValue);',
+        },
+    ],
+    invalid: [
+        {
+            code: 'const filtered = items.filter((item) => item.name.toLowerCase().includes(searchValue.toLowerCase()));',
+            errors: [{
+                message,
+            }],
+        },
+        {
+            code: 'const searchResults = data.filter(entry => entry.title.toLowerCase().includes(query.toLowerCase()));',
+            errors: [{
+                message,
+            }],
+        },
+        {
+            code: 'const enabledSearchTaxRates = enabledTaxRatesWithoutSelectedOptions.filter((taxRate) => taxRate.modifiedName?.toLowerCase().includes(searchValue.toLowerCase()));',
+            errors: [{
+                message,
+            }],
+        },
+        {
+            code: 'const searchCategories = categoriesForSearch.filter((category) => {return category.name.toLowerCase().includes(searchValue.toLowerCase());});',
+            errors: [{
+                message,
+            }],
+        },
+        {
+            // eslint-disable-next-line max-len
+            code: 'const filteredOptions = membersDetails.filter((option) => {return !!option.text?.toLowerCase().includes(searchValue) || !!option.alternateText?.toLowerCase().includes(searchValue);});',
+            errors: [{
+                message,
+            }],
+        },
+        {
+            code: 'const filtered = exportMenuItem?.data.filter((option) => {return option.value.toLowerCase().includes(searchText);});',
+            errors: [{
+                message,
+            }],
+        },
+        {
+            code: 'const filtered = array.filter(({ searchText }) => {return searchText.toLowerCase().includes(searchValue.toLowerCase());});',
+            errors: [{
+                message,
+            }],
+        },
+        {
+            code: `
+                const filteredApprovers = debouncedSearchTerm !== ''
+                    ? approvers.filter((option) => {
+                        const searchValue = getSearchValueForPhoneOrEmail(debouncedSearchTerm);
+                        const isPartOfSearchTerm = !!option.text?.toLowerCase().includes(searchValue) || !!option.login?.toLowerCase().includes(searchValue);
+                        return isPartOfSearchTerm;
+                    })
+                    : approvers;
+            `,
+            errors: [{
+                message,
+            }],
+        },
+        {
+            code: `
+                const enabledSearchTags = enabledTagsWithoutSelectedOptions.filter((tag) => {
+                    return PolicyUtils.getCleanedTagName(tag.name.toLowerCase()).includes(searchValue.toLowerCase());
+                });
+            `,
+            errors: [{message}],
+        },
+        {
+            code: `
+                const filteredOptions = [...formattedPolicyAdmins, ...formattedAuthorizedPayer].filter((option) => {
+                    const searchValue = OptionsListUtils.getSearchValueForPhoneOrEmail(searchTerm);
+                    return !!option.text?.toLowerCase().includes(searchValue) || !!option.login?.toLowerCase().includes(searchValue);
+                });
+            `,
+            errors: [{message}],
+        },
+    ],
+});

--- a/rules/expensify.js
+++ b/rules/expensify.js
@@ -30,6 +30,7 @@ module.exports = {
         }],
         'rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth': 'warn',
         'rulesdir/no-use-state-initializer-functions': 'error',
+        'rulesdir/prefer-tokenized-search': 'warn',
     },
 };
 


### PR DESCRIPTION
This PR introduces the prefer-tokenized-search ESLint rule to enforce the use of tokenized search instead of direct string .includes() comparisons. The rule identifies instances where .filter() is used with .includes() on a .toLowerCase() result and suggests to use tokenized search function.

Updated version of [this PR](https://github.com/Expensify/eslint-config-expensify/pull/141)
Logic remains the same