### PR TITLE
Allow for...of loops in JS

### DIFF
--- a/rules/es6.js
+++ b/rules/es6.js
@@ -26,5 +26,8 @@ module.exports = {
 
         // Use of `this` outside class methods can lead to crashes on minified code
         'no-invalid-this': 'error',
+
+        // Override no-restricted-syntax to allow for...of loops
+        'no-restricted-syntax': ['error', 'ForInStatement', 'LabeledStatement', 'WithStatement'],
     },
 };

--- a/rules/es6.js
+++ b/rules/es6.js
@@ -28,6 +28,20 @@ module.exports = {
         'no-invalid-this': 'error',
 
         // Override no-restricted-syntax to allow for...of loops
-        'no-restricted-syntax': ['error', 'ForInStatement', 'LabeledStatement', 'WithStatement'],
+        'no-restricted-syntax': ['error',
+            {
+                selector: 'ForInStatement',
+                message: 'for..in loops iterate over the entire prototype chain, which is virtually never what you want. '
+                    + 'Use Object.{keys,values,entries}, and iterate over the resulting array.',
+            },
+            {
+                selector: 'LabeledStatement',
+                message: 'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
+            },
+            {
+                selector: 'WithStatement',
+                message: '`with` is disallowed in strict mode because it makes code impossible to predict and optimize. It is also deprecated',
+            },
+        ],
     },
 };

--- a/rules/es6.js
+++ b/rules/es6.js
@@ -40,7 +40,7 @@ module.exports = {
             },
             {
                 selector: 'WithStatement',
-                message: '`with` is disallowed in strict mode because it makes code impossible to predict and optimize. It is also deprecated',
+                message: '`with` is disallowed in strict mode because it makes code impossible to predict and optimize. It is also deprecated.',
             },
         ],
     },


### PR DESCRIPTION
Coming from https://expensify.slack.com/archives/C05LX9D6E07/p1744240759624819, this PR allows the use of `for...of` loops in JavaScript.

The error messages and other included rules come from the AirBnB source: https://github.com/airbnb/javascript/blob/11f986fdc7d6b4c80e396437e9c45c939362bdee/packages/eslint-config-airbnb-base/rules/style.js#L340-L358

I tested this with:

1. Write a `for...of` loop in react-native-onyx
1. Verify that there's a lint error
1. Make the change in this PR in `react-native-onyx/node_modules/eslint-config-expensify`
1. Verify that the lint error disappears
1. Write a `for...in` loop in react-native-onyx
1. Verify that there's a lint error