### PR TITLE
Follow up #148 - fix rule

### DIFF
--- a/eslint-plugin-expensify/no-beta-handler.js
+++ b/eslint-plugin-expensify/no-beta-handler.js
@@ -100,7 +100,7 @@ module.exports = {
             // Visit FunctionDeclaration nodes (e.g., `function canUseAutoSubmit(...) { ... }`)
             FunctionDeclaration(node) {
                 // Check if the function body is a block statement
-                if (node.id.name === 'isBetaEnabled' || !node.body || node.body.type !== 'BlockStatement') {
+                if ((node.id && node.id.name === 'isBetaEnabled') || !node.body || node.body.type !== 'BlockStatement') {
                     return;
                 }
                 for (const statement of node.body.body) {
@@ -117,7 +117,7 @@ module.exports = {
             // Visit VariableDeclarator nodes (e.g., `const canUseAutoSubmit = (betas) => { ... };`)
             VariableDeclarator(node) {
                 // Ensure it's an arrow function or function expression
-                if (node.id.name === 'isBetaEnabled' || !node.init || !(node.init.type === 'ArrowFunctionExpression' || node.init.type === 'FunctionExpression')) {
+                if ((node.id && node.id.name === 'isBetaEnabled') || !node.init || !(node.init.type === 'ArrowFunctionExpression' || node.init.type === 'FunctionExpression')) {
                     return;
                 }
                 const funcBody = node.init.body;


### PR DESCRIPTION
### Explanation

Prevent creation of custom beta-handler functions such as `canUseSomething`. Instead force the user to use `isBetaEnabled` handler to check for betas. 

Issue # https://github.com/Expensify/App/issues/64317

<img width="1234" alt="Screenshot 2025-07-04 at 3 13 57 PM" src="https://github.com/user-attachments/assets/e81e788a-284e-428f-8011-79d9384f79f4" />



cc: @grgia 