### PR TITLE
Add `prefer-locale-compare-from-context` rule

### DIFF
--- a/eslint-plugin-expensify/CONST.js
+++ b/eslint-plugin-expensify/CONST.js
@@ -35,6 +35,7 @@ module.exports = {
         PREFER_TYPE_FEST_VALUE_OF: 'Prefer using `ValueOf` from `type-fest` to extract the type of the properties of an object.',
         PREFER_AT: 'Prefer using the `.at()` method for array element access.',
         PREFER_SHOULD_USE_NARROW_LAYOUT_INSTEAD_OF_IS_SMALL_SCREEN_WIDTH: 'Prefer using `shouldUseNarrowLayout` instead of `isSmallScreenWidth` from `useResponsiveLayout`.',
+        PREFER_LOCALE_COMPARE_FROM_CONTEXT: 'Prefer using `localeCompare` from `useLocalize` for performance.',
         NO_USE_STATE_INITIALIZER_CALL_FUNCTION:
             'Avoid calling a function directly in the useState initializer. Use an initializer function instead (a callback).',
     },

--- a/eslint-plugin-expensify/boolean-conditional-rendering.js
+++ b/eslint-plugin-expensify/boolean-conditional-rendering.js
@@ -1,7 +1,5 @@
-/* eslint-disable no-bitwise */
-const _ = require('underscore');
 const {ESLintUtils} = require('@typescript-eslint/utils');
-const ts = require('typescript');
+const {isBoolean} = require('./utils/typeUtil');
 
 module.exports = {
     name: 'boolean-conditional-rendering',
@@ -21,24 +19,7 @@ module.exports = {
         function isJSXElement(node) {
             return node.type === 'JSXElement' || node.type === 'JSXFragment';
         }
-        function isBoolean(type) {
-            return (
-                (type.getFlags()
-          & (ts.TypeFlags.Boolean
-            | ts.TypeFlags.BooleanLike
-            | ts.TypeFlags.BooleanLiteral))
-          !== 0
-        || (type.isUnion()
-          && _.every(
-              type.types,
-              t => (t.getFlags()
-                & (ts.TypeFlags.Boolean
-                  | ts.TypeFlags.BooleanLike
-                  | ts.TypeFlags.BooleanLiteral))
-              !== 0,
-          ))
-            );
-        }
+
         const parserServices = ESLintUtils.getParserServices(context);
         const typeChecker = parserServices.program.getTypeChecker();
         return {

--- a/eslint-plugin-expensify/prefer-locale-compare-from-context.js
+++ b/eslint-plugin-expensify/prefer-locale-compare-from-context.js
@@ -1,0 +1,61 @@
+const {ESLintUtils} = require('@typescript-eslint/utils');
+const lodashGet = require('lodash/get');
+const {isInTestFile} = require('./utils');
+const {isString} = require('./utils/typeUtil');
+const message = require('./CONST').MESSAGE.PREFER_LOCALE_COMPARE_FROM_CONTEXT;
+
+/**
+ * @typedef {import('eslint').Rule.RuleModule} RuleModule
+ */
+
+function isLocaleCompareMethod(node) {
+    return lodashGet(node, 'callee.type') === 'MemberExpression'
+        && lodashGet(node, 'callee.property.name') === 'localeCompare';
+}
+
+/** @type {RuleModule} */
+module.exports = {
+    name: 'prefer-locale-compare-from-context',
+    meta: {
+        type: 'problem',
+        docs: {
+            description: message,
+        },
+    },
+    create(context) {
+        const parserServices = ESLintUtils.getParserServices(context);
+        const typeChecker = parserServices.program.getTypeChecker();
+
+        function isUsingIncorrectLocaleCompareMethod(node) {
+            if (!isLocaleCompareMethod(node)) {
+                return false;
+            }
+
+            const objectNode = node.callee.object;
+            if (!objectNode) {
+                return false;
+            }
+
+            const objectTsNode = parserServices.esTreeNodeToTSNodeMap.get(objectNode);
+            const objectType = typeChecker.getTypeAtLocation(objectTsNode);
+            return isString(objectType);
+        }
+
+        return {
+            CallExpression(node) {
+                if (isInTestFile(context.filename)) {
+                    return;
+                }
+
+                if (!isUsingIncorrectLocaleCompareMethod(node)) {
+                    return;
+                }
+
+                context.report({
+                    node,
+                    message,
+                });
+            },
+        };
+    },
+};

--- a/eslint-plugin-expensify/tests/prefer-locale-compare-from-context.test.js
+++ b/eslint-plugin-expensify/tests/prefer-locale-compare-from-context.test.js
@@ -1,0 +1,66 @@
+const RuleTester = require('@typescript-eslint/rule-tester').RuleTester;
+const rule = require('../prefer-locale-compare-from-context');
+const message = require('../CONST').MESSAGE.PREFER_LOCALE_COMPARE_FROM_CONTEXT;
+
+const ruleTester = new RuleTester({
+    parser: '@typescript-eslint/parser',
+    parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: __dirname,
+        sourceType: 'module',
+        ecmaVersion: 2020,
+    },
+});
+
+ruleTester.run('prefer-locale-compare-from-context', rule, {
+    valid: [
+        {
+            code: `
+                const localeCompare = (a, b) => {};
+                const result = localeCompare(a, b);
+            `,
+            filename: 'file.ts',
+        },
+        {
+            code: `
+                const notAString = {};
+                const result = notAString.localeCompare('xyz');
+            `,
+            filename: 'file.ts',
+        },
+
+        // Test files should be ignored
+        {
+            code: `
+                const str = 'abc';
+                const result = str.localeCompare('xyz');
+            `,
+            filename: '../tests/file.ts',
+        },
+    ],
+    invalid: [
+        {
+            code: `
+                const str = 'abc';
+                const result = str.localeCompare('xyz');
+            `,
+            errors: [{message}],
+            filename: 'file.ts',
+        },
+        {
+            code: `
+                const getString = () => 'abc';
+                const result = getString().localeCompare('xyz');
+            `,
+            errors: [{message}],
+            filename: 'file.ts',
+        },
+        {
+            code: `
+                'abc'.localeCompare('xyz');
+            `,
+            errors: [{message}],
+            filename: 'file.ts',
+        },
+    ],
+});

--- a/eslint-plugin-expensify/utils/typeUtil.js
+++ b/eslint-plugin-expensify/utils/typeUtil.js
@@ -1,0 +1,22 @@
+/* eslint-disable no-bitwise */
+const _ = require('underscore');
+const ts = require('typescript');
+
+function isBoolean(type) {
+    if ((type.flags & (ts.TypeFlags.Boolean | ts.TypeFlags.BooleanLike | ts.TypeFlags.BooleanLiteral)) !== 0) {
+        return true;
+    }
+    return type.isUnion() && _.every(type.types, isBoolean);
+}
+
+function isString(type) {
+    if ((type.flags & (ts.TypeFlags.String | ts.TypeFlags.StringLike | ts.TypeFlags.StringLiteral)) !== 0) {
+        return true;
+    }
+    return type.isUnion() && _.every(type.types, isString);
+}
+
+module.exports = {
+    isBoolean,
+    isString,
+};


### PR DESCRIPTION
### Explanation

Issue: https://github.com/Expensify/App/issues/67426

When we use `someString.localeCompare(...)`, we implicitly create a new Intl.Collator object, which incurs significant performance overhead. This lint rule enforces the use of localeCompare from E/App's LocaleContextProvider, where a single Intl.Collator object is created once and reduced between localeCompare calls, with much less overhead.
