### PR TITLE
Add globals to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-rulesdir": "^0.2.2",
+        "globals": "^15.14.0",
         "lodash": "^4.17.21",
         "underscore": "^1.13.6"
       },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-rulesdir": "^0.2.2",
+    "globals": "^15.14.0",
     "lodash": "^4.17.21",
     "underscore": "^1.13.6"
   },


### PR DESCRIPTION
As part of the ESLint 9 upgrade, `globals` was used as a sub-dependency, but its version isn't guaranteed and could have [an upstream issue](https://github.com/sindresorhus/globals/issues/239) in old versions. This PR adds it explicitly to the dependencies specifies the version as `^15.14.0`.