### PR TITLE
Allow "NotFound" as an exception in no-negated-variables

### DIFF
--- a/eslint-plugin-expensify/no-negated-variables.js
+++ b/eslint-plugin-expensify/no-negated-variables.js
@@ -13,6 +13,13 @@ const BANNED_SUBSTRINGS = [
     'dont',
 ];
 
+// Whitelisted morphemes/domain concepts that happen to contain a banned substring.
+// Entries may be:
+//   - Single English words (e.g. "notification") — matched loosely so natural
+//     suffixes like plural "Notifications" or "Notches" still count.
+//   - camelCase compounds (e.g. "notFound") — matched only when followed by a
+//     word boundary (next char is uppercase/underscore/end), so we do not
+//     accidentally whitelist unrelated words like "Foundation".
 const NOTABLE_EXCEPTIONS = [
     'notification',
     'notify',
@@ -21,16 +28,53 @@ const NOTABLE_EXCEPTIONS = [
     'notable',
     'notion',
     'notice',
+    'notFound',
 ];
+
+/**
+ * @param {String} word
+ * @returns {String}
+ */
+function camelToUpperSnake(word) {
+    return word.replaceAll(/([a-z])([A-Z])/g, '$1_$2').toUpperCase();
+}
+
+/**
+ * Build the list of regex alternatives that identify an occurrence of an
+ * exception word inside a larger identifier. Multi-word exceptions require a
+ * trailing word boundary so that they do not leak into unrelated identifiers.
+ *
+ * @param {String} word
+ * @returns {String[]}
+ */
+function buildExceptionAlternatives(word) {
+    const hasInternalCap = /[a-z][A-Z]/.test(word);
+    const upperFirst = word[0].toUpperCase() + word.slice(1);
+    const lowerFirst = word[0].toLowerCase() + word.slice(1);
+    const snake = camelToUpperSnake(word);
+
+    if (hasInternalCap) {
+        return [
+            `${upperFirst}(?=[A-Z_]|$)`,
+            `${lowerFirst}(?=[A-Z_]|$)`,
+            `_?${snake}(?=_|$)`,
+        ];
+    }
+
+    return [
+        upperFirst,
+        lowerFirst,
+        `_?${snake}_?`,
+    ];
+}
 
 /**
  * @param {String} string
  * @returns {Boolean}
  */
 function isFalsePositive(string) {
-    const buzzWordMatcher = new RegExp(`[nN](?:${_.map(NOTABLE_EXCEPTIONS, word => word.slice(1)).join('|')})`);
-    const upperSnakeCaseMatcher = new RegExp(`_?${_.map(NOTABLE_EXCEPTIONS, word => word.toUpperCase()).join('|')}_?`);
-    const regex = new RegExp(`(.*)(?:${buzzWordMatcher.source}|${upperSnakeCaseMatcher.source})(.*)`, 'm');
+    const alternatives = _.flatten(_.map(NOTABLE_EXCEPTIONS, buildExceptionAlternatives));
+    const regex = new RegExp(`(.*?)(?:${alternatives.join('|')})(.*)`, 'm');
     const matches = regex.exec(string);
 
     if (!matches) {
@@ -54,7 +98,7 @@ function isFalsePositive(string) {
  */
 function isNegatedVariableName(name) {
     if (!name) {
-        return;
+        return false;
     }
 
     return _.any(BANNED_SUBSTRINGS, badSubstring => name.toLowerCase().includes(badSubstring))

--- a/eslint-plugin-expensify/tests/no-negated-variables.test.js
+++ b/eslint-plugin-expensify/tests/no-negated-variables.test.js
@@ -49,6 +49,24 @@ ruleTester.run('no-negated-variables', rule, {
         {
             code: 'const NOTABLE_EXCEPTIONS = [];',
         },
+        {
+            code: 'const shouldShowNotFoundPage = true;',
+        },
+        {
+            code: 'function ReportNotFoundGuard() {}',
+        },
+        {
+            code: 'const IOURequestStepTaxRatePageWithWritableReportOrNotFound = withWritableReportOrNotFound(IOURequestStepTaxRatePage);',
+        },
+        {
+            code: 'const IS_NOT_FOUND = true;',
+        },
+        {
+            code: 'const isReportNotFound = () => false;',
+        },
+        {
+            code: 'const memberNotFoundMessage = "";',
+        },
     ],
     invalid: [
         {
@@ -107,6 +125,36 @@ ruleTester.run('no-negated-variables', rule, {
         },
         {
             code: 'const THIS_IS_NOT_GOOD = true;',
+            errors: [{
+                message,
+            }],
+        },
+        {
+            code: 'const participantNotSelected = {};',
+            errors: [{
+                message,
+            }],
+        },
+        {
+            code: 'const cannotBeFlagged = true;',
+            errors: [{
+                message,
+            }],
+        },
+        {
+            code: 'const isNotFoundation = true;',
+            errors: [{
+                message,
+            }],
+        },
+        {
+            code: 'const NOT_FOUNDATION = true;',
+            errors: [{
+                message,
+            }],
+        },
+        {
+            code: 'const isTripNotInitialized = false;',
             errors: [{
                 message,
             }],


### PR DESCRIPTION
## Summary

Generalize the `NOTABLE_EXCEPTIONS` matcher in [`no-negated-variables.js`](eslint-plugin-expensify/no-negated-variables.js) and whitelist `notFound` / `NotFound` / `NOT_FOUND` as a domain concept (HTTP 404 / missing entity).

### Motivation

A survey of `Expensify/App` found **~110 `rulesdir/no-negated-variables` suppressions across ~70 files**. Roughly 90% of them fall into one of these patterns, none of which is actually a double negation:

- `shouldShowNotFoundPage`, `shouldShowNotFoundView`, `shouldShowNotFoundLinkedAction`
- HOC bindings: `XxxWithWritableReportOrNotFound`, `XxxWithFullTransactionOrNotFound`, `withReportOrNotFound`, `withReportAndReportActionOrNotFound`, `withReportAndPrivateNotesOrNotFound`
- Components/pages/guards: `ReportNotFoundGuard`, `LinkedActionNotFoundGuard`, `NotFoundPage`, `FullPageNotFoundView`, `DomainNotFoundPageWrapper`, `RuleNotFoundPageWrapper`, `AccessOrNotFoundWrapper`, `memberNotFoundMessage`, `isReportNotFound`

The previous matcher only supported single-word exceptions starting with `n` (regex was hardcoded to `[nN](?:<word-without-first-letter>)`) and only handled `_?EXCEPTION_?` for UPPER_SNAKE — so `NOT_FOUND` (underscore in the middle) could never be whitelisted.

### What changed

1. Introduced `buildExceptionAlternatives(word)` that emits:
   - For single-word exceptions (`notification`, `note`, `notch`, …): loose matching so natural morphology like `Notifications` / `Notches` still counts.
   - For multi-word camelCase exceptions (`notFound`): a trailing word-boundary lookahead `(?=[A-Z_]|$)` for camel forms and `(?=_|$)` for the snake form, so we do **not** whitelist unrelated words like `Foundation`.
2. Added `'notFound'` to `NOTABLE_EXCEPTIONS`.
3. Preserved the existing prefix/suffix recursion so compound names such as `isNotNotification` and `notificationsThatAreNotOfNote` are still correctly flagged.

### Genuine catches remain flagged

New invalid tests assert the rule still flags:

- `const participantNotSelected = {};`
- `const cannotBeFlagged = true;`
- `const isTripNotInitialized = false;`
- `const isNotFoundation = true;` (the new boundary check prevents `NotFound` from leaking into `Foundation`)
- `const NOT_FOUNDATION = true;`

### Expected follow-up

Once this lands and is published, a follow-up PR in `Expensify/App` can remove the ~100 now-redundant `// eslint-disable-next-line rulesdir/no-negated-variables` comments.

## Test plan

- [x] `npm test` — 467/467 tests pass (35 suites), including the 11 new cases in [`tests/no-negated-variables.test.js`](eslint-plugin-expensify/tests/no-negated-variables.test.js).
- [x] `npm run lint` on the edited files passes.
- [ ] Verify in `Expensify/App` that removing the `NotFound`-related suppressions no longer triggers the rule.

Made with [Cursor](https://cursor.com)