### PR TITLE
Remove react/jsx-props-no-spreading

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -497,15 +497,6 @@ const config = defineConfig([{
         // TODO: set to "static public field" once babel-preset-airbnb supports public class fields
         'react/static-property-placement': ['error', 'property assignment'],
 
-        // Disallow JSX props spreading
-        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-spreading.md
-        'react/jsx-props-no-spreading': ['error', {
-            html: 'enforce',
-            custom: 'enforce',
-            explicitSpread: 'ignore',
-            exceptions: [],
-        }],
-
         // Enforce that props are read-only
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-read-only-props.md
         'react/prefer-read-only-props': 'off',


### PR DESCRIPTION
slack thread: https://expensify.slack.com/archives/C08CZDJFJ77/p1778733618077709

## Summary

Removing `react/jsx-props-no-spreading`, because it has been suppressed 391 times in E/App and isn't useful in a TypeScript codebase.

## Motivation

Prop spreading is a common and idiomatic pattern in TypeScript codebases — forwarding typed props, building HOCs, wrapping generic components, etc. TypeScript's type system already prevents misuse of spread props at compile time, making the ESLint rule redundant and overly restrictive for `.ts`/`.tsx` files.