### PR TITLE
Remove no-async-await and no-continue rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 import {defineConfig} from 'eslint/config';
-import eslintPluginLwc from '@lwc/eslint-plugin-lwc';
 import es from 'eslint-plugin-es';
 import rulesdir from 'eslint-plugin-rulesdir';
 import globals from 'globals';
@@ -46,7 +45,6 @@ const config = defineConfig([
         },
 
         plugins: {
-            '@lwc/lwc': eslintPluginLwc,
             es,
             rulesdir,
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "@babel/eslint-parser": "^7.28.4",
-        "@lwc/eslint-plugin-lwc": "^3.2.0",
         "@typescript-eslint/parser": "^8.44.1",
         "@typescript-eslint/utils": "^8.44.1",
         "confusing-browser-globals": "^1.0.11",
@@ -1523,24 +1522,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@lwc/eslint-plugin-lwc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-3.2.0.tgz",
-      "integrity": "sha512-feK85eUxdFci+bQMzuTuUBKYpig81e4Wl0Wib++K3P7mizEnD7GRLyxIW4uVD/aLhrmX9CXAwRZXVB60hotXkg==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-xml-parser": "^4.5.1",
-        "globals": "~15.14.0",
-        "minimatch": "~9.0.4"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "@babel/eslint-parser": "^7",
-        "eslint": "^9"
       }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -4131,24 +4112,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
-      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "strnum": "^1.1.1"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -8287,18 +8250,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/strnum": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -9959,16 +9910,6 @@
       "requires": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "@lwc/eslint-plugin-lwc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-3.2.0.tgz",
-      "integrity": "sha512-feK85eUxdFci+bQMzuTuUBKYpig81e4Wl0Wib++K3P7mizEnD7GRLyxIW4uVD/aLhrmX9CXAwRZXVB60hotXkg==",
-      "requires": {
-        "fast-xml-parser": "^4.5.1",
-        "globals": "~15.14.0",
-        "minimatch": "~9.0.4"
       }
     },
     "@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -11770,14 +11711,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
-    },
-    "fast-xml-parser": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
-      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
-      "requires": {
-        "strnum": "^1.1.1"
-      }
     },
     "fastq": {
       "version": "1.19.1",
@@ -14647,11 +14580,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
-    },
-    "strnum": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA=="
     },
     "supports-color": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "type": "module",
   "dependencies": {
     "@babel/eslint-parser": "^7.28.4",
-    "@lwc/eslint-plugin-lwc": "^3.2.0",
     "@typescript-eslint/parser": "^8.44.1",
     "@typescript-eslint/utils": "^8.44.1",
     "confusing-browser-globals": "^1.0.11",

--- a/rules/base/style.js
+++ b/rules/base/style.js
@@ -294,10 +294,6 @@ const config = defineConfig([{
         // https://eslint.org/docs/rules/no-bitwise
         'no-bitwise': 'error',
 
-        // allow use of the continue statement
-        // https://eslint.org/docs/rules/no-continue
-        'no-continue': 'off',
-
         // disallow comments inline after code
         'no-inline-comments': 'off',
 

--- a/rules/es6.js
+++ b/rules/es6.js
@@ -19,9 +19,6 @@ const config = defineConfig([{
             requireForBlockBody: true,
         }],
 
-        // Do not allow the use of async/await
-        '@lwc/lwc/no-async-await': 'error',
-
         // Do not use these features yet
         'es/no-nullish-coalescing-operators': 'error',
         'es/no-optional-chaining': 'error',


### PR DESCRIPTION
## Summary
These rules are suppressed in consuming repos. Removing them from the base simplifies our configs and removes an external dep.

## Test plan
n/a