### PR TITLE
Allow @jest-environment JSDoc tag in jest config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Just add `extends: 'expensify/legacy'` to the `.eslintrc` file in the root direc
 
 ### eslint-config-expensify/jest
 
-Opt-in config for Jest test, mock, and setup files. Enables Jest globals, `eslint-plugin-jest` recommended and style rules, and relaxes `no-console`, `no-await-in-loop`, and `no-import-assign` for test files.
+Opt-in config for Jest test, mock, and setup files. Enables Jest globals, `eslint-plugin-jest` recommended and style rules, relaxes `no-console`, `no-await-in-loop`, and `no-import-assign` for test files, and allows the `@jest-environment` JSDoc tag via `jsdoc/check-tag-names`.
 
 ```js
 import {defineConfig} from 'eslint/config';

--- a/configs/public/jest.js
+++ b/configs/public/jest.js
@@ -17,6 +17,9 @@ const config = defineConfig([{
         'no-console': 'off',
         'no-await-in-loop': 'off',
         'no-import-assign': 'off',
+        'jsdoc/check-tag-names': ['error', {
+            definedTags: ['jest-environment'],
+        }],
     },
 }]);
 


### PR DESCRIPTION
## Summary
- Adds `jsdoc/check-tag-names` to `eslint-config-expensify/jest` with `definedTags: ['jest-environment']`
- Allows inline Jest environment configuration (`@jest-environment jsdom`, etc.) in test files without conflicting with the base style rules
- Updates README to document the new behavior