### PR TITLE
Stop re-enabling class-methods-use-this in react config

### DIFF
--- a/configs/public/react.js
+++ b/configs/public/react.js
@@ -28,27 +28,6 @@ const config = defineConfig([
                 enforceInMethodNames: true,
             }],
 
-            'class-methods-use-this': ['error', {
-                exceptMethods: [
-                    'render',
-                    'getInitialState',
-                    'getDefaultProps',
-                    'getChildContext',
-                    'componentWillMount',
-                    'UNSAFE_componentWillMount',
-                    'componentDidMount',
-                    'componentWillReceiveProps',
-                    'UNSAFE_componentWillReceiveProps',
-                    'shouldComponentUpdate',
-                    'componentWillUpdate',
-                    'UNSAFE_componentWillUpdate',
-                    'componentDidUpdate',
-                    'componentWillUnmount',
-                    'componentDidCatch',
-                    'getSnapshotBeforeUpdate',
-                ],
-            }],
-
             // Prevent missing displayName in a React component definition
             // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/display-name.md
             'react/display-name': ['off', {ignoreTranspilerName: false}],


### PR DESCRIPTION
## Summary

- Removes `class-methods-use-this` from `configs/public/react.js`.
- Lets the existing `class-methods-use-this: off` in `configs/private/style.js` stand when consumers spread `browser` + `react` configs.
- Eliminates the need for App, react-native-onyx, and other consumers to re-disable this rule locally after adopting the react sub-config.

### Background

`style.js` already disables `class-methods-use-this` as an Expensify style preference. The react sub-config was re-enabling it (inherited from the Airbnb react preset), which forced every consumer to override it back to `off`. Instance methods that don't use `this` are common in Expensify codebases for interface implementations and API shape (e.g. no-op class stubs).

## Test plan

1. Run `npm test` and confirm all tests pass.
2. Verify a consumer config that spreads `browser` + `react` no longer enables `class-methods-use-this` (rule should be `off` from style.js).
