### PR TITLE
Whitelist notation and annotation in no-negated-variables

### DIFF
--- a/eslint-plugin-expensify/no-negated-variables.js
+++ b/eslint-plugin-expensify/no-negated-variables.js
@@ -28,6 +28,8 @@ const NOTABLE_EXCEPTIONS = [
     'notable',
     'notion',
     'notice',
+    'notation',
+    'annotation',
     'notFound',
 ];
 

--- a/eslint-plugin-expensify/tests/no-negated-variables.test.js
+++ b/eslint-plugin-expensify/tests/no-negated-variables.test.js
@@ -67,6 +67,21 @@ ruleTester.run('no-negated-variables', rule, {
         {
             code: 'const memberNotFoundMessage = "";',
         },
+        {
+            code: 'const notation = {};',
+        },
+        {
+            code: 'const annotation = {};',
+        },
+        {
+            code: 'const musicalNotation = {};',
+        },
+        {
+            code: 'const textAnnotation = {};',
+        },
+        {
+            code: 'const ANNOTATION = {};',
+        },
     ],
     invalid: [
         {


### PR DESCRIPTION
## Summary
- `rulesdir/no-negated-variables` was incorrectly flagging identifiers containing `notation` or `annotation` because they include the banned `not` substring
- Added both words to the existing `NOTABLE_EXCEPTIONS` whitelist
- Added test coverage for bare, compound, and uppercase variants

## Test plan
- [x] `npm test -- eslint-plugin-expensify/tests/no-negated-variables.test.js`
- [x] Verified `notation` and `annotation` no longer trigger the rule
- [x] Existing invalid cases (e.g. `isNotValid`, `participantNotSelected`) still fail as expected


Made with [Cursor](https://cursor.com)