### PR TITLE
Detect inline factory-call selectors in `no-inline-useOnyx-selector`

### DIFF
--- a/eslint-plugin-expensify/no-inline-useOnyx-selector.js
+++ b/eslint-plugin-expensify/no-inline-useOnyx-selector.js
@@ -16,6 +16,9 @@ const meta = {
         noNonMemoizedSelector: 'useOnyx() selector defined within component should be memoized with useCallback.\n\n'
             + 'Wrap the selector function with useCallback to prevent unnecessary re-renders:\n\n'
             + 'const memoizedSelector = useCallback((val) => ({...}), [dependencies]);',
+        noInlineFactorySelector: 'useOnyx() selector is produced by a factory call inline, so it returns a new function on every render.\n\n'
+            + 'Memoize the factory result with useMemo so the reference stays stable:\n\n'
+            + 'const memoizedSelector = useMemo(() => makeSelector(arg), [arg]);',
     },
 };
 
@@ -44,12 +47,12 @@ function create(context) {
     }
 
     /**
-     * Check if a variable is defined with useCallback.
+     * Check if a variable is defined with a memoization hook (useCallback or useMemo).
      *
      * @param {Variable} variable - The variable to check.
      * @returns {boolean}
      */
-    function isDefinedWithUseCallback(variable) {
+    function isDefinedWithMemoHook(variable) {
         if (!variable || variable.defs.length === 0) {
             return false;
         }
@@ -57,7 +60,7 @@ function create(context) {
         const def = variable.defs[0];
         if (def.node.init && def.node.init.type === 'CallExpression') {
             const callee = def.node.init.callee;
-            return callee.name === 'useCallback';
+            return callee.name === 'useCallback' || callee.name === 'useMemo';
         }
 
         return false;
@@ -99,6 +102,16 @@ function create(context) {
     }
 
     /**
+     * Check if a property is a selector defined by an inline factory call, e.g. `selector: makeSelector(arg)`.
+     *
+     * @param {Property} property - The property to check.
+     * @returns {boolean}
+     */
+    function isFactorySelector(property) {
+        return property.type === 'Property' && property.key.name === 'selector' && property.value.type === 'CallExpression';
+    }
+
+    /**
      * Check if an object has an inline selector property.
      *
      * @param {ObjectExpression} objectExpression - The object to check.
@@ -125,7 +138,7 @@ function create(context) {
             return; // Variable not found in current scope
         }
 
-        if (isDefinedInCurrentComponent(variable) && !isDefinedWithUseCallback(variable)) {
+        if (isDefinedInCurrentComponent(variable) && !isDefinedWithMemoHook(variable)) {
             context.report({
                 node,
                 messageId: 'noNonMemoizedSelector',
@@ -191,6 +204,11 @@ function create(context) {
                             node: node.init,
                             messageId: 'noInlineSelector',
                         });
+                    } else if (_.some(optionsArgument.properties, isFactorySelector)) {
+                        context.report({
+                            node: node.init,
+                            messageId: 'noInlineFactorySelector',
+                        });
                     } else {
                         const selectorProperty = findProperty(optionsArgument, 'selector');
                         if (selectorProperty && selectorProperty.value.type === 'Identifier') {
@@ -206,6 +224,11 @@ function create(context) {
                         context.report({
                             node: node.init,
                             messageId: 'noInlineSelector',
+                        });
+                    } else if (resolvedValue && _.some(resolvedValue.properties, isFactorySelector)) {
+                        context.report({
+                            node: node.init,
+                            messageId: 'noInlineFactorySelector',
                         });
                     } else if (resolvedValue) {
                         const selectorProperty = findProperty(resolvedValue, 'selector');

--- a/eslint-plugin-expensify/no-inline-useOnyx-selector.js
+++ b/eslint-plugin-expensify/no-inline-useOnyx-selector.js
@@ -122,6 +122,16 @@ function create(context) {
     }
 
     /**
+     * Check if an object has a selector property defined by an inline factory call.
+     *
+     * @param {ObjectExpression} objectExpression - The object to check.
+     * @returns {boolean}
+     */
+    function hasFactorySelector(objectExpression) {
+        return _.some(objectExpression.properties, isFactorySelector);
+    }
+
+    /**
      * Check if a selector identifier should be memoized within component.
      *
      * @param {string} selectorName - The name of the selector identifier.
@@ -216,7 +226,7 @@ function create(context) {
                             node: node.init,
                             messageId: 'noInlineSelector',
                         });
-                    } else if (_.some(optionsArgument.properties, isFactorySelector)) {
+                    } else if (hasFactorySelector(optionsArgument)) {
                         context.report({
                             node: node.init,
                             messageId: 'noInlineFactorySelector',
@@ -237,7 +247,7 @@ function create(context) {
                             node: node.init,
                             messageId: 'noInlineSelector',
                         });
-                    } else if (resolvedValue && _.some(resolvedValue.properties, isFactorySelector)) {
+                    } else if (resolvedValue && hasFactorySelector(resolvedValue)) {
                         context.report({
                             node: node.init,
                             messageId: 'noInlineFactorySelector',

--- a/eslint-plugin-expensify/no-inline-useOnyx-selector.js
+++ b/eslint-plugin-expensify/no-inline-useOnyx-selector.js
@@ -139,6 +139,18 @@ function create(context) {
         }
 
         if (isDefinedInCurrentComponent(variable) && !isDefinedWithMemoHook(variable)) {
+            const init = variable.defs[0].node.init;
+
+            // A factory call assigned to a plain variable returns a new function on every render,
+            // so it needs to be memoized with useMemo rather than useCallback.
+            if (init && init.type === 'CallExpression') {
+                context.report({
+                    node,
+                    messageId: 'noInlineFactorySelector',
+                });
+                return;
+            }
+
             context.report({
                 node,
                 messageId: 'noNonMemoizedSelector',

--- a/eslint-plugin-expensify/tests/no-inline-useOnyx-selector.test.js
+++ b/eslint-plugin-expensify/tests/no-inline-useOnyx-selector.test.js
@@ -58,6 +58,15 @@ ruleTester.run('no-inline-useOnyx-selector', rule, {
             }`,
         },
 
+        // Factory result memoized with useMemo within component - should not error
+        {
+            code: `function MyComponent() {
+                const memoizedSelector = useMemo(() => makeSelector(arg), [arg]);
+                const [data] = useOnyx(ONYXKEYS.DATA, {selector: memoizedSelector});
+                return null;
+            }`,
+        },
+
         // Selector defined with useCallback in options object within component - should not error
         {
             code: `function MyComponent() {
@@ -123,6 +132,34 @@ ruleTester.run('no-inline-useOnyx-selector', rule, {
             code: 'const options = {selector: function(data) { return data.value; }, canBeMissing: false}; const [data] = useOnyx(ONYXKEYS.DATA, options);',
             errors: [{
                 messageId: 'noInlineSelector',
+            }],
+        },
+
+        // Inline factory call selector - should error
+        {
+            code: 'const [data] = useOnyx(ONYXKEYS.DATA, {selector: makeSelector(id), canBeMissing: false});',
+            errors: [{
+                messageId: 'noInlineFactorySelector',
+            }],
+        },
+
+        // Options as variable with factory call selector - should error
+        {
+            code: 'const options = {selector: makeSelector(id)}; const [data] = useOnyx(ONYXKEYS.DATA, options);',
+            errors: [{
+                messageId: 'noInlineFactorySelector',
+            }],
+        },
+
+        // Factory result assigned to a plain (non-memoized) variable within component - should error
+        {
+            code: `function MyComponent() {
+                const nonMemoizedSelector = makeSelector(arg);
+                const [data] = useOnyx(ONYXKEYS.DATA, {selector: nonMemoizedSelector});
+                return null;
+            }`,
+            errors: [{
+                messageId: 'noNonMemoizedSelector',
             }],
         },
 

--- a/eslint-plugin-expensify/tests/no-inline-useOnyx-selector.test.js
+++ b/eslint-plugin-expensify/tests/no-inline-useOnyx-selector.test.js
@@ -159,7 +159,7 @@ ruleTester.run('no-inline-useOnyx-selector', rule, {
                 return null;
             }`,
             errors: [{
-                messageId: 'noNonMemoizedSelector',
+                messageId: 'noInlineFactorySelector',
             }],
         },
 


### PR DESCRIPTION
## Summary

Extend the `no-inline-useOnyx-selector` rule to also flag selectors produced by an inline factory
call, e.g. `useOnyx(KEY, {selector: makeSelector(arg)})`. Also accept `useMemo` (not just
`useCallback`) as valid memoization, since `useMemo` is the idiomatic way to stabilize a factory
selector.

## Background

The rule previously recognized only two `selector` shapes:

- inline arrow / function expression → `noInlineSelector`
- in-component identifier not memoized with `useCallback` → `noNonMemoizedSelector`

A selector produced by an inline factory call is a `CallExpression`, which matched neither branch,
so it was silently allowed. This is just as unstable as an inline arrow: the factory runs on every
render and returns a new function reference each time. In React Compiler bailout files (where the
rule is supposed to catch missing manual memoization) these went completely unreported.

The fix:

- Add `isFactorySelector` + a `noInlineFactorySelector` message, wired into both the
  `ObjectExpression` and resolved-identifier option branches.
- Broaden the memoization check to accept `useMemo` as well as `useCallback`
  (`isDefinedWithUseCallback` → `isDefinedWithMemoHook`). `useMemo(() => makeSelector(arg), [arg])`
  is the recommended fix for factory selectors, so it must not be flagged as non-memoized.

## Test plan

- `npm test` — 25/25 cases pass, including new coverage:
  - invalid: inline factory call selector (direct object, with other options, via options variable)
  - invalid: factory result assigned to a plain non-memoized in-component variable
  - valid: factory result memoized with `useMemo`